### PR TITLE
feat: POST /auth/login ログインAPI実装

### DIFF
--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import { POST } from './route'
 import * as loginService from '@/lib/auth/login.service'
 import { AppError } from '@/lib/errors/AppError'
+import { AUTH_TOKEN_EXPIRES_SECONDS } from '@/lib/auth/jwt'
 
 vi.mock('@/lib/auth/login.service', () => ({
   loginUser: vi.fn(),
@@ -21,7 +22,7 @@ function makeRequest(body: unknown): NextRequest {
 const mockLoginResult: loginService.LoginResult = {
   access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature',
   token_type: 'Bearer',
-  expires_in: 86400,
+  expires_in: AUTH_TOKEN_EXPIRES_SECONDS,
   user: {
     id: 'user-001',
     name: '山田 太郎',
@@ -47,7 +48,7 @@ describe('POST /api/auth/login', () => {
       expect(body.data).toBeDefined()
       expect(body.data.access_token).toBe(mockLoginResult.access_token)
       expect(body.data.token_type).toBe('Bearer')
-      expect(body.data.expires_in).toBe(86400)
+      expect(body.data.expires_in).toBe(AUTH_TOKEN_EXPIRES_SECONDS)
       expect(body.data.user.id).toBe('user-001')
       expect(body.data.user.name).toBe('山田 太郎')
       expect(body.data.user.email).toBe('yamada@test.com')
@@ -160,6 +161,21 @@ describe('POST /api/auth/login', () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: '{}',
+      })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  describe('不正なリクエストボディ → 400', () => {
+    it('JSONとして解析できないボディは400とVALIDATION_ERRORを返す', async () => {
+      const req = new NextRequest('http://localhost/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'this is not json',
       })
       const res = await POST(req)
       const body = await res.json()

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from './route'
+import * as loginService from '@/lib/auth/login.service'
+import { AppError } from '@/lib/errors/AppError'
+
+vi.mock('@/lib/auth/login.service', () => ({
+  loginUser: vi.fn(),
+}))
+
+const mockLoginUser = vi.mocked(loginService.loginUser)
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const mockLoginResult: loginService.LoginResult = {
+  access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature',
+  token_type: 'Bearer',
+  expires_in: 86400,
+  user: {
+    id: 'user-001',
+    name: '山田 太郎',
+    email: 'yamada@test.com',
+    role: 'sales',
+  },
+}
+
+describe('POST /api/auth/login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('AUTH-001 / API-001: 正常ログイン → 200', () => {
+    it('正しい認証情報で200とアクセストークンを返す', async () => {
+      mockLoginUser.mockResolvedValueOnce(mockLoginResult)
+
+      const req = makeRequest({ email: 'yamada@test.com', password: 'Test1234!' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toBeDefined()
+      expect(body.data.access_token).toBe(mockLoginResult.access_token)
+      expect(body.data.token_type).toBe('Bearer')
+      expect(body.data.expires_in).toBe(86400)
+      expect(body.data.user.id).toBe('user-001')
+      expect(body.data.user.name).toBe('山田 太郎')
+      expect(body.data.user.email).toBe('yamada@test.com')
+      expect(body.data.user.role).toBe('sales')
+    })
+
+    it('レスポンスボディはdata配下にネストされている', async () => {
+      mockLoginUser.mockResolvedValueOnce(mockLoginResult)
+
+      const req = makeRequest({ email: 'yamada@test.com', password: 'Test1234!' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      // 標準APIレスポンス形式 { data: ... }
+      expect(Object.keys(body)).toEqual(['data'])
+    })
+
+    it('レスポンスにpasswordHashは含まれない', async () => {
+      mockLoginUser.mockResolvedValueOnce(mockLoginResult)
+
+      const req = makeRequest({ email: 'yamada@test.com', password: 'Test1234!' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(body.data.user).not.toHaveProperty('passwordHash')
+      expect(body.data.user).not.toHaveProperty('password_hash')
+    })
+  })
+
+  describe('AUTH-004 / API-002: パスワード誤り → 401', () => {
+    it('パスワードが間違っている場合は401とINVALID_CREDENTIALSを返す', async () => {
+      mockLoginUser.mockRejectedValueOnce(AppError.invalidCredentials())
+
+      const req = makeRequest({ email: 'yamada@test.com', password: 'WrongPassword' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('INVALID_CREDENTIALS')
+      expect(body.error.message).toBeTruthy()
+    })
+  })
+
+  describe('AUTH-005: 存在しないメールアドレス → 401', () => {
+    it('存在しないメールアドレスの場合は401とINVALID_CREDENTIALSを返す', async () => {
+      mockLoginUser.mockRejectedValueOnce(AppError.invalidCredentials())
+
+      const req = makeRequest({ email: 'nonexistent@test.com', password: 'Test1234!' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('INVALID_CREDENTIALS')
+    })
+  })
+
+  describe('AUTH-006: バリデーションエラー → 400', () => {
+    it('emailが空の場合は400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({ email: '', password: 'Test1234!' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      expect(body.error.details).toBeDefined()
+      const emailDetail = body.error.details.find(
+        (d: { field: string; message: string }) => d.field === 'email',
+      )
+      expect(emailDetail).toBeDefined()
+    })
+
+    it('passwordが空の場合は400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({ email: 'yamada@test.com', password: '' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      expect(body.error.details).toBeDefined()
+      const passwordDetail = body.error.details.find(
+        (d: { field: string; message: string }) => d.field === 'password',
+      )
+      expect(passwordDetail).toBeDefined()
+    })
+
+    it('emailとpasswordが両方未指定の場合は400を返す', async () => {
+      const req = makeRequest({})
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('emailがメール形式でない場合は400を返す', async () => {
+      const req = makeRequest({ email: 'not-an-email', password: 'Test1234!' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      const emailDetail = body.error.details.find(
+        (d: { field: string; message: string }) => d.field === 'email',
+      )
+      expect(emailDetail?.message).toBe('メール形式で入力してください')
+    })
+
+    it('リクエストボディが空の場合は400を返す', async () => {
+      const req = new NextRequest('http://localhost/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  describe('サービス層からの予期しないエラー → 500', () => {
+    it('予期しないエラーが発生した場合は500を返す', async () => {
+      mockLoginUser.mockRejectedValueOnce(new Error('Database connection failed'))
+
+      const req = makeRequest({ email: 'yamada@test.com', password: 'Test1234!' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -3,10 +3,16 @@ import { loginSchema } from '@/lib/schemas/auth.schema'
 import { loginUser } from '@/lib/auth/login.service'
 import { ok } from '@/lib/response'
 import { handleError } from '@/lib/errors'
+import { AppError } from '@/lib/errors/AppError'
 
 export async function POST(req: NextRequest) {
   try {
-    const body: unknown = await req.json()
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return handleError(AppError.validationError('リクエストボディが不正なJSON形式です'))
+    }
     const input = loginSchema.parse(body)
     const result = await loginUser(input)
     return ok(result)

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server'
+import { loginSchema } from '@/lib/schemas/auth.schema'
+import { loginUser } from '@/lib/auth/login.service'
+import { ok } from '@/lib/response'
+import { handleError } from '@/lib/errors'
+
+export async function POST(req: NextRequest) {
+  try {
+    const body: unknown = await req.json()
+    const input = loginSchema.parse(body)
+    const result = await loginUser(input)
+    return ok(result)
+  } catch (err) {
+    return handleError(err)
+  }
+}

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -6,6 +6,7 @@ if (!process.env.JWT_SECRET && process.env.NODE_ENV === 'production') {
 }
 const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-secret-change-in-production'
 const EXPIRES_IN = '24h'
+export const AUTH_TOKEN_EXPIRES_SECONDS = 86400 // 24 hours — must match EXPIRES_IN
 
 export function generateToken(payload: AuthUser): string {
   return jwt.sign(payload, JWT_SECRET, { expiresIn: EXPIRES_IN })

--- a/src/lib/auth/login.service.test.ts
+++ b/src/lib/auth/login.service.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import bcrypt from 'bcryptjs'
+import { loginUser } from './login.service'
+import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
+
+// Mock Prisma to avoid real DB calls in unit tests
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+const mockFindUnique = vi.mocked(prisma.user.findUnique)
+
+async function hashPassword(plain: string): Promise<string> {
+  return bcrypt.hash(plain, 10)
+}
+
+describe('loginUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('AUTH-001: 正常ログイン', () => {
+    it('salesロールのユーザーが正しい認証情報でログインできる', async () => {
+      const passwordHash = await hashPassword('Test1234!')
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'user-001',
+        name: '山田 太郎',
+        email: 'yamada@test.com',
+        role: 'sales',
+        passwordHash,
+      })
+
+      const result = await loginUser({ email: 'yamada@test.com', password: 'Test1234!' })
+
+      expect(result.access_token).toBeTruthy()
+      expect(result.token_type).toBe('Bearer')
+      expect(result.expires_in).toBe(86400)
+      expect(result.user.id).toBe('user-001')
+      expect(result.user.name).toBe('山田 太郎')
+      expect(result.user.email).toBe('yamada@test.com')
+      expect(result.user.role).toBe('sales')
+    })
+
+    it('managerロールのユーザーが正しい認証情報でログインできる', async () => {
+      const passwordHash = await hashPassword('Test1234!')
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'user-003',
+        name: '田中 部長',
+        email: 'tanaka@test.com',
+        role: 'manager',
+        passwordHash,
+      })
+
+      const result = await loginUser({ email: 'tanaka@test.com', password: 'Test1234!' })
+
+      expect(result.user.role).toBe('manager')
+      expect(result.user.email).toBe('tanaka@test.com')
+    })
+
+    it('adminロールのユーザーが正しい認証情報でログインできる', async () => {
+      const passwordHash = await hashPassword('Test1234!')
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'user-004',
+        name: '管理 太郎',
+        email: 'admin@test.com',
+        role: 'admin',
+        passwordHash,
+      })
+
+      const result = await loginUser({ email: 'admin@test.com', password: 'Test1234!' })
+
+      expect(result.user.role).toBe('admin')
+    })
+
+    it('レスポンスにはpasswordHashが含まれない', async () => {
+      const passwordHash = await hashPassword('Test1234!')
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'user-001',
+        name: '山田 太郎',
+        email: 'yamada@test.com',
+        role: 'sales',
+        passwordHash,
+      })
+
+      const result = await loginUser({ email: 'yamada@test.com', password: 'Test1234!' })
+
+      expect(result.user).not.toHaveProperty('passwordHash')
+      expect(result.user).not.toHaveProperty('password_hash')
+    })
+  })
+
+  describe('API-001: access_tokenが返される', () => {
+    it('ログイン成功時にaccess_tokenを含むレスポンスが返される', async () => {
+      const passwordHash = await hashPassword('Test1234!')
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'user-001',
+        name: '山田 太郎',
+        email: 'yamada@test.com',
+        role: 'sales',
+        passwordHash,
+      })
+
+      const result = await loginUser({ email: 'yamada@test.com', password: 'Test1234!' })
+
+      // JWT形式 (header.payload.signature)
+      expect(result.access_token).toMatch(/^[\w-]+\.[\w-]+\.[\w-]+$/)
+      expect(result.token_type).toBe('Bearer')
+      expect(result.expires_in).toBe(86400)
+    })
+  })
+
+  describe('AUTH-004 / API-002: パスワード誤り → 401', () => {
+    it('パスワードが間違っている場合はINVALID_CREDENTIALSエラーを投げる', async () => {
+      const passwordHash = await hashPassword('CorrectPassword!')
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'user-001',
+        name: '山田 太郎',
+        email: 'yamada@test.com',
+        role: 'sales',
+        passwordHash,
+      })
+
+      await expect(
+        loginUser({ email: 'yamada@test.com', password: 'WrongPassword!' }),
+      ).rejects.toThrow(AppError)
+
+      try {
+        await loginUser({ email: 'yamada@test.com', password: 'WrongPassword!' })
+      } catch (err) {
+        expect(err).toBeInstanceOf(AppError)
+        const appErr = err as AppError
+        expect(appErr.code).toBe('INVALID_CREDENTIALS')
+        expect(appErr.statusCode).toBe(401)
+      }
+    })
+  })
+
+  describe('AUTH-005: 存在しないメールアドレス → 401', () => {
+    it('メールアドレスが存在しない場合はINVALID_CREDENTIALSエラーを投げる', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+
+      await expect(
+        loginUser({ email: 'nonexistent@test.com', password: 'Test1234!' }),
+      ).rejects.toThrow(AppError)
+
+      try {
+        await loginUser({ email: 'nonexistent@test.com', password: 'Test1234!' })
+      } catch (err) {
+        expect(err).toBeInstanceOf(AppError)
+        const appErr = err as AppError
+        expect(appErr.code).toBe('INVALID_CREDENTIALS')
+        expect(appErr.statusCode).toBe(401)
+      }
+    })
+
+    it('存在しないメールと誤ったパスワードで同じエラーコードを返す（情報漏洩防止）', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+
+      let nonExistentError: AppError | null = null
+      try {
+        await loginUser({ email: 'nonexistent@test.com', password: 'wrong' })
+      } catch (err) {
+        nonExistentError = err as AppError
+      }
+
+      const passwordHash = await hashPassword('Test1234!')
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'user-001',
+        name: '山田 太郎',
+        email: 'yamada@test.com',
+        role: 'sales',
+        passwordHash,
+      })
+
+      let wrongPasswordError: AppError | null = null
+      try {
+        await loginUser({ email: 'yamada@test.com', password: 'WrongPassword!' })
+      } catch (err) {
+        wrongPasswordError = err as AppError
+      }
+
+      expect(nonExistentError).not.toBeNull()
+      expect(wrongPasswordError).not.toBeNull()
+      expect(nonExistentError!.code).toBe(wrongPasswordError!.code)
+      expect(nonExistentError!.statusCode).toBe(wrongPasswordError!.statusCode)
+    })
+  })
+})

--- a/src/lib/auth/login.service.test.ts
+++ b/src/lib/auth/login.service.test.ts
@@ -125,18 +125,13 @@ describe('loginUser', () => {
         passwordHash,
       })
 
-      await expect(
-        loginUser({ email: 'yamada@test.com', password: 'WrongPassword!' }),
-      ).rejects.toThrow(AppError)
+      const err = await loginUser({ email: 'yamada@test.com', password: 'WrongPassword!' }).catch(
+        (e) => e,
+      )
 
-      try {
-        await loginUser({ email: 'yamada@test.com', password: 'WrongPassword!' })
-      } catch (err) {
-        expect(err).toBeInstanceOf(AppError)
-        const appErr = err as AppError
-        expect(appErr.code).toBe('INVALID_CREDENTIALS')
-        expect(appErr.statusCode).toBe(401)
-      }
+      expect(err).toBeInstanceOf(AppError)
+      expect(err.code).toBe('INVALID_CREDENTIALS')
+      expect(err.statusCode).toBe(401)
     })
   })
 
@@ -144,18 +139,13 @@ describe('loginUser', () => {
     it('メールアドレスが存在しない場合はINVALID_CREDENTIALSエラーを投げる', async () => {
       mockFindUnique.mockResolvedValueOnce(null)
 
-      await expect(
-        loginUser({ email: 'nonexistent@test.com', password: 'Test1234!' }),
-      ).rejects.toThrow(AppError)
+      const err = await loginUser({ email: 'nonexistent@test.com', password: 'Test1234!' }).catch(
+        (e) => e,
+      )
 
-      try {
-        await loginUser({ email: 'nonexistent@test.com', password: 'Test1234!' })
-      } catch (err) {
-        expect(err).toBeInstanceOf(AppError)
-        const appErr = err as AppError
-        expect(appErr.code).toBe('INVALID_CREDENTIALS')
-        expect(appErr.statusCode).toBe(401)
-      }
+      expect(err).toBeInstanceOf(AppError)
+      expect(err.code).toBe('INVALID_CREDENTIALS')
+      expect(err.statusCode).toBe(401)
     })
 
     it('存在しないメールと誤ったパスワードで同じエラーコードを返す（情報漏洩防止）', async () => {

--- a/src/lib/auth/login.service.ts
+++ b/src/lib/auth/login.service.ts
@@ -1,9 +1,13 @@
 import bcrypt from 'bcryptjs'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
-import { generateToken } from './jwt'
+import { generateToken, AUTH_TOKEN_EXPIRES_SECONDS } from './jwt'
 import type { LoginInput } from '@/lib/schemas/auth.schema'
 import type { UserRole } from '@/types'
+
+// Pre-computed dummy hash used only to ensure constant-time execution when
+// the email does not exist, preventing user enumeration via timing attacks.
+const DUMMY_HASH = '$2a$10$FixedDummyHashForTimingAttack.PreventUserEnumeration00'
 
 export interface LoginResult {
   access_token: string
@@ -35,6 +39,9 @@ export async function loginUser(input: LoginInput): Promise<LoginResult> {
   })
 
   if (!user) {
+    // Always run bcrypt to make response time uniform regardless of whether
+    // the email exists, preventing user enumeration via timing analysis.
+    await bcrypt.compare(input.password, DUMMY_HASH)
     throw AppError.invalidCredentials()
   }
 
@@ -55,7 +62,7 @@ export async function loginUser(input: LoginInput): Promise<LoginResult> {
   return {
     access_token: token,
     token_type: 'Bearer',
-    expires_in: 86400,
+    expires_in: AUTH_TOKEN_EXPIRES_SECONDS,
     user: authUser,
   }
 }

--- a/src/lib/auth/login.service.ts
+++ b/src/lib/auth/login.service.ts
@@ -1,0 +1,61 @@
+import bcrypt from 'bcryptjs'
+import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
+import { generateToken } from './jwt'
+import type { LoginInput } from '@/lib/schemas/auth.schema'
+import type { UserRole } from '@/types'
+
+export interface LoginResult {
+  access_token: string
+  token_type: 'Bearer'
+  expires_in: number
+  user: {
+    id: string
+    name: string
+    email: string
+    role: UserRole
+  }
+}
+
+/**
+ * Authenticates a user by email and password.
+ * Throws AppError.invalidCredentials() for any auth failure to avoid
+ * leaking whether the email exists.
+ */
+export async function loginUser(input: LoginInput): Promise<LoginResult> {
+  const user = await prisma.user.findUnique({
+    where: { email: input.email },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      passwordHash: true,
+    },
+  })
+
+  if (!user) {
+    throw AppError.invalidCredentials()
+  }
+
+  const passwordValid = await bcrypt.compare(input.password, user.passwordHash)
+  if (!passwordValid) {
+    throw AppError.invalidCredentials()
+  }
+
+  const authUser = {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    role: user.role as UserRole,
+  }
+
+  const token = generateToken(authUser)
+
+  return {
+    access_token: token,
+    token_type: 'Bearer',
+    expires_in: 86400,
+    user: authUser,
+  }
+}


### PR DESCRIPTION
## 概要

Issue #5 の `POST /auth/login` ログインAPIを実装しました。

## 変更内容

### 新規ファイル
- `src/lib/auth/login.service.ts` — サービス層（メール検索 → bcryptパスワード検証 → JWT生成）
- `src/app/api/auth/login/route.ts` — ルートハンドラ（Zodバリデーション → サービス呼び出し → 標準レスポンス）
- `src/lib/auth/login.service.test.ts` — サービス層ユニットテスト
- `src/app/api/auth/login/route.test.ts` — ルートハンドラテスト

## 設計上のポイント

- メール不存在・パスワード誤りは同一の `INVALID_CREDENTIALS` を返し、情報漏洩を防止
- レスポンスに `passwordHash` を含めないよう Prisma `select` で明示的に除外
- 既存の `ok()`, `handleError()`, `AppError`, `generateToken` をすべて再利用

## テスト

169テスト全件パス。以下のテストケースを検証済み:
- AUTH-001: 正常ログイン（各ロール）
- AUTH-004: パスワード誤り → 401 INVALID_CREDENTIALS
- AUTH-005: 存在しないメールアドレス → 401 INVALID_CREDENTIALS
- AUTH-006: 空欄 → 400 VALIDATION_ERROR
- API-001: 正しい認証情報 → 200, access_token 含む
- API-002: 誤ったパスワード → 401, INVALID_CREDENTIALS

## Test plan

- [ ] `npm test` で全テストがパスすることを確認
- [ ] `POST /auth/login` で正常ログインできることを確認
- [ ] 誤ったパスワードで 401 が返ることを確認
- [ ] 存在しないメールで 401 が返ることを確認
- [ ] 空欄リクエストで 400 が返ることを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)