### PR TITLE
feat: GET /reports 日報一覧API実装 (closes #7)

### DIFF
--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -1,0 +1,516 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+import * as reportsService from '@/lib/reports/reports.service'
+import { generateToken } from '@/lib/auth/jwt'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+import type { ListReportsResult } from '@/lib/reports/reports.service'
+
+vi.mock('@/lib/reports/reports.service', () => ({
+  listReports: vi.fn(),
+}))
+
+// Mock the blacklist so tokens are never invalidated in tests
+vi.mock('@/lib/auth/blacklist', () => ({
+  isBlacklisted: vi.fn().mockReturnValue(false),
+}))
+
+const mockListReports = vi.mocked(reportsService.listReports)
+
+// ─── Test users ──────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const salesUser2: AuthUser = {
+  id: '22222222-2222-2222-2222-222222222222',
+  name: '鈴木 一郎',
+  email: 'suzuki@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRequest(user: AuthUser, queryString = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/reports${queryString}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+    },
+  })
+}
+
+function makeRequestWithoutAuth(queryString = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/reports${queryString}`, {
+    method: 'GET',
+  })
+}
+
+function makeRequestWithInvalidToken(queryString = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/reports${queryString}`, {
+    method: 'GET',
+    headers: { Authorization: 'Bearer not-a-valid-jwt' },
+  })
+}
+
+// ─── Sample data ─────────────────────────────────────────────────────────────
+
+const sampleReport = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  report_date: '2026-04-18',
+  problem: '課題テキスト',
+  plan: '翌日予定テキスト',
+  user: { id: salesUser.id, name: salesUser.name },
+  visit_records: [
+    {
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      customer: { id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', name: '佐藤 健', company: '株式会社A' },
+      content: '商談内容',
+      sort_order: 1,
+    },
+  ],
+  comments_count: 0,
+  created_at: '2026-04-18T09:00:00.000Z',
+  updated_at: '2026-04-18T09:00:00.000Z',
+}
+
+const defaultMeta = { total: 1, page: 1, per_page: 20 }
+
+const singleItemResult: ListReportsResult = {
+  data: [sampleReport],
+  meta: defaultMeta,
+}
+
+const emptyResult: ListReportsResult = {
+  data: [],
+  meta: { total: 0, page: 1, per_page: 20 },
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Authentication ──────────────────────────────────────────────────────────
+
+  describe('認証', () => {
+    it('AUTH-P01: Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = makeRequestWithoutAuth()
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('無効なJWTトークンの場合は401を返す', async () => {
+      const req = makeRequestWithInvalidToken()
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  // ── Access control — sales role ─────────────────────────────────────────────
+
+  describe('API-011 / AUTH-P02: salesロールは自分の日報のみ取得できる', () => {
+    it('salesユーザーで200を返し、listReportsにsalesユーザー自身が渡される', async () => {
+      mockListReports.mockResolvedValueOnce(singleItemResult)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(1)
+      expect(body.meta.total).toBe(1)
+      expect(body.meta.page).toBe(1)
+      expect(body.meta.per_page).toBe(20)
+    })
+
+    it('salesユーザーがuser_idクエリを指定しても、サービス呼び出しには本人IDが使われる', async () => {
+      mockListReports.mockResolvedValueOnce(emptyResult)
+
+      // sales user passes another user's id — should be overridden in service layer
+      const req = makeRequest(salesUser, `?user_id=${salesUser2.id}`)
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      // Verify that listReports was called with the sales user (not the query user_id)
+      // The override happens inside listReports; the route passes the query as-is and the
+      // service enforces the scope. Here we verify the query was forwarded correctly.
+      expect(mockListReports).toHaveBeenCalledWith(
+        salesUser,
+        expect.objectContaining({ user_id: salesUser2.id }),
+      )
+    })
+
+    it('salesユーザーのレスポンスにはdata[]とmetaが含まれる', async () => {
+      mockListReports.mockResolvedValueOnce(singleItemResult)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(body).toHaveProperty('data')
+      expect(body).toHaveProperty('meta')
+      expect(Array.isArray(body.data)).toBe(true)
+    })
+  })
+
+  // ── Access control — manager/admin ─────────────────────────────────────────
+
+  describe('API-012 / AUTH-P01: managerは全ユーザーの日報を取得できる', () => {
+    it('managerユーザーで200を返す', async () => {
+      const multiUserResult: ListReportsResult = {
+        data: [
+          sampleReport,
+          { ...sampleReport, id: 'report-002', user: { id: salesUser2.id, name: salesUser2.name } },
+        ],
+        meta: { total: 2, page: 1, per_page: 20 },
+      }
+      mockListReports.mockResolvedValueOnce(multiUserResult)
+
+      const req = makeRequest(managerUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(2)
+      expect(body.meta.total).toBe(2)
+    })
+
+    it('adminユーザーで200を返す', async () => {
+      mockListReports.mockResolvedValueOnce(singleItemResult)
+
+      const req = makeRequest(adminUser)
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  // ── user_id filter ──────────────────────────────────────────────────────────
+
+  describe('API-013: managerがuser_idフィルタで絞り込める', () => {
+    it('managerがuser_idを指定するとlistReportsにuser_idが渡される', async () => {
+      mockListReports.mockResolvedValueOnce(singleItemResult)
+
+      const req = makeRequest(managerUser, `?user_id=${salesUser.id}`)
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      expect(mockListReports).toHaveBeenCalledWith(
+        managerUser,
+        expect.objectContaining({ user_id: salesUser.id }),
+      )
+    })
+
+    it('user_idが無効なUUID形式の場合は400を返す', async () => {
+      const req = makeRequest(managerUser, '?user_id=not-a-uuid')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // ── Date range filters ──────────────────────────────────────────────────────
+
+  describe('日付フィルタ', () => {
+    it('date_fromとdate_toを指定するとlistReportsに渡される', async () => {
+      mockListReports.mockResolvedValueOnce(singleItemResult)
+
+      const req = makeRequest(managerUser, '?date_from=2026-04-01&date_to=2026-04-18')
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      expect(mockListReports).toHaveBeenCalledWith(
+        managerUser,
+        expect.objectContaining({ date_from: '2026-04-01', date_to: '2026-04-18' }),
+      )
+    })
+
+    it('date_fromが不正な形式の場合は400を返す', async () => {
+      const req = makeRequest(salesUser, '?date_from=2026/04/01')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('date_toが不正な形式の場合は400を返す', async () => {
+      const req = makeRequest(salesUser, '?date_to=not-a-date')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('date_fromのみ指定できる（date_toなし）', async () => {
+      mockListReports.mockResolvedValueOnce(emptyResult)
+
+      const req = makeRequest(salesUser, '?date_from=2026-04-01')
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      expect(mockListReports).toHaveBeenCalledWith(
+        salesUser,
+        expect.objectContaining({ date_from: '2026-04-01' }),
+      )
+    })
+
+    it('date_toのみ指定できる（date_fromなし）', async () => {
+      mockListReports.mockResolvedValueOnce(emptyResult)
+
+      const req = makeRequest(salesUser, '?date_to=2026-04-18')
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      expect(mockListReports).toHaveBeenCalledWith(
+        salesUser,
+        expect.objectContaining({ date_to: '2026-04-18' }),
+      )
+    })
+  })
+
+  // ── Pagination ──────────────────────────────────────────────────────────────
+
+  describe('ページネーション', () => {
+    it('pageとper_pageを指定するとlistReportsに渡される', async () => {
+      mockListReports.mockResolvedValueOnce({
+        data: [],
+        meta: { total: 0, page: 2, per_page: 10 },
+      })
+
+      const req = makeRequest(salesUser, '?page=2&per_page=10')
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      expect(mockListReports).toHaveBeenCalledWith(
+        salesUser,
+        expect.objectContaining({ page: 2, per_page: 10 }),
+      )
+    })
+
+    it('クエリパラメータなしの場合はデフォルト値（page=1, per_page=20）が使われる', async () => {
+      mockListReports.mockResolvedValueOnce(emptyResult)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      expect(mockListReports).toHaveBeenCalledWith(
+        salesUser,
+        expect.objectContaining({ page: 1, per_page: 20 }),
+      )
+    })
+
+    it('per_pageが100を超える場合は400を返す', async () => {
+      const req = makeRequest(salesUser, '?per_page=101')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('per_pageが1の場合は有効（下限境界値）', async () => {
+      mockListReports.mockResolvedValueOnce({
+        data: [sampleReport],
+        meta: { total: 1, page: 1, per_page: 1 },
+      })
+
+      const req = makeRequest(salesUser, '?per_page=1')
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+    })
+
+    it('per_pageが100の場合は有効（上限境界値）', async () => {
+      mockListReports.mockResolvedValueOnce({
+        data: [],
+        meta: { total: 0, page: 1, per_page: 100 },
+      })
+
+      const req = makeRequest(salesUser, '?per_page=100')
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+    })
+
+    it('pageが0以下の場合は400を返す', async () => {
+      const req = makeRequest(salesUser, '?page=0')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('per_pageが0以下の場合は400を返す', async () => {
+      const req = makeRequest(salesUser, '?per_page=0')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // ── Response shape ──────────────────────────────────────────────────────────
+
+  describe('レスポンス形式', () => {
+    it('レスポンスのdataには日報フィールドが含まれる', async () => {
+      mockListReports.mockResolvedValueOnce(singleItemResult)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      const report = body.data[0]
+      expect(report.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+      expect(report.report_date).toBe(sampleReport.report_date)
+      expect(report.problem).toBe(sampleReport.problem)
+      expect(report.plan).toBe(sampleReport.plan)
+      expect(report.user.id).toBe(salesUser.id)
+      expect(report.user.name).toBe(salesUser.name)
+    })
+
+    it('visit_recordsにはcustomer情報が含まれる', async () => {
+      mockListReports.mockResolvedValueOnce(singleItemResult)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      const vr = body.data[0].visit_records[0]
+      expect(vr.id).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+      expect(vr.customer.id).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc')
+      expect(vr.customer.name).toBe('佐藤 健')
+      expect(vr.customer.company).toBe('株式会社A')
+      expect(vr.content).toBe('商談内容')
+      expect(vr.sort_order).toBe(1)
+    })
+
+    it('comments_countがレスポンスに含まれる', async () => {
+      const reportWithComments = {
+        ...sampleReport,
+        comments_count: 3,
+      }
+      mockListReports.mockResolvedValueOnce({
+        data: [reportWithComments],
+        meta: defaultMeta,
+      })
+
+      const req = makeRequest(managerUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(body.data[0].comments_count).toBe(3)
+    })
+
+    it('metaにtotal、page、per_pageが含まれる', async () => {
+      mockListReports.mockResolvedValueOnce({
+        data: [],
+        meta: { total: 45, page: 3, per_page: 10 },
+      })
+
+      const req = makeRequest(salesUser, '?page=3&per_page=10')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(body.meta.total).toBe(45)
+      expect(body.meta.page).toBe(3)
+      expect(body.meta.per_page).toBe(10)
+    })
+
+    it('日報が0件の場合はdataが空配列で200を返す', async () => {
+      mockListReports.mockResolvedValueOnce(emptyResult)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toEqual([])
+      expect(body.meta.total).toBe(0)
+    })
+  })
+
+  // ── Error handling ──────────────────────────────────────────────────────────
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockListReports.mockRejectedValueOnce(new Error('Database connection failed'))
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+
+    it('サービスがAppErrorをスローした場合は対応するHTTPステータスを返す', async () => {
+      mockListReports.mockRejectedValueOnce(AppError.notFound('日報'))
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+  })
+
+  // ── Combined filter scenarios ───────────────────────────────────────────────
+
+  describe('複合フィルタ', () => {
+    it('managerがuser_id・date_from・date_toを同時に指定できる', async () => {
+      mockListReports.mockResolvedValueOnce(singleItemResult)
+
+      const req = makeRequest(
+        managerUser,
+        `?user_id=${salesUser.id}&date_from=2026-04-01&date_to=2026-04-18`,
+      )
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      expect(mockListReports).toHaveBeenCalledWith(
+        managerUser,
+        expect.objectContaining({
+          user_id: salesUser.id,
+          date_from: '2026-04-01',
+          date_to: '2026-04-18',
+        }),
+      )
+    })
+  })
+})

--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -151,7 +151,7 @@ describe('GET /api/reports', () => {
       expect(body.meta.per_page).toBe(20)
     })
 
-    it('salesユーザーがuser_idクエリを指定しても、サービス呼び出しには本人IDが使われる', async () => {
+    it('salesユーザーがuser_idクエリを指定しても、クエリはそのままサービスに転送される（スコープ制限はサービス層で行う）', async () => {
       mockListReports.mockResolvedValueOnce(emptyResult)
 
       // sales user passes another user's id — should be overridden in service layer

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/guard'
+import { listReportsQuerySchema } from '@/lib/schemas/report.schema'
+import { listReports } from '@/lib/reports/reports.service'
+import { handleError } from '@/lib/errors'
+import type { AuthUser } from '@/types'
+
+async function handleGetReports(
+  req: NextRequest,
+  _context: Record<string, unknown>,
+  user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const searchParams = req.nextUrl.searchParams
+
+    // Build raw query object from search params for Zod parsing
+    const rawQuery: Record<string, string | undefined> = {
+      user_id: searchParams.get('user_id') ?? undefined,
+      date_from: searchParams.get('date_from') ?? undefined,
+      date_to: searchParams.get('date_to') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+    }
+
+    // Remove undefined keys so Zod optional() works correctly
+    Object.keys(rawQuery).forEach((key) => {
+      if (rawQuery[key] === undefined) {
+        delete rawQuery[key]
+      }
+    })
+
+    const query = listReportsQuerySchema.parse(rawQuery)
+    const result = await listReports(user, query)
+
+    return NextResponse.json(result)
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const GET = withAuth(handleGetReports)

--- a/src/lib/auth/login.service.test.ts
+++ b/src/lib/auth/login.service.test.ts
@@ -33,6 +33,8 @@ describe('loginUser', () => {
         email: 'yamada@test.com',
         role: 'sales',
         passwordHash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
 
       const result = await loginUser({ email: 'yamada@test.com', password: 'Test1234!' })
@@ -54,6 +56,8 @@ describe('loginUser', () => {
         email: 'tanaka@test.com',
         role: 'manager',
         passwordHash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
 
       const result = await loginUser({ email: 'tanaka@test.com', password: 'Test1234!' })
@@ -70,6 +74,8 @@ describe('loginUser', () => {
         email: 'admin@test.com',
         role: 'admin',
         passwordHash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
 
       const result = await loginUser({ email: 'admin@test.com', password: 'Test1234!' })
@@ -85,6 +91,8 @@ describe('loginUser', () => {
         email: 'yamada@test.com',
         role: 'sales',
         passwordHash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
 
       const result = await loginUser({ email: 'yamada@test.com', password: 'Test1234!' })
@@ -103,6 +111,8 @@ describe('loginUser', () => {
         email: 'yamada@test.com',
         role: 'sales',
         passwordHash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
 
       const result = await loginUser({ email: 'yamada@test.com', password: 'Test1234!' })
@@ -123,6 +133,8 @@ describe('loginUser', () => {
         email: 'yamada@test.com',
         role: 'sales',
         passwordHash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
 
       const err = await loginUser({ email: 'yamada@test.com', password: 'WrongPassword!' }).catch(
@@ -165,6 +177,8 @@ describe('loginUser', () => {
         email: 'yamada@test.com',
         role: 'sales',
         passwordHash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
 
       let wrongPasswordError: AppError | null = null

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { listReports } from './reports.service'
+import { prisma } from '@/lib/prisma'
+import type { AuthUser } from '@/types'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    dailyReport: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+const mockCount = vi.mocked(prisma.dailyReport.count)
+const mockFindMany = vi.mocked(prisma.dailyReport.findMany)
+
+// ─── Test users ───────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const salesUser2: AuthUser = {
+  id: '22222222-2222-2222-2222-222222222222',
+  name: '鈴木 一郎',
+  email: 'suzuki@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample Prisma records ────────────────────────────────────────────────────
+
+function makePrismaReport(overrides: Partial<{
+  id: string
+  userId: string
+  reportDate: Date
+  userName: string
+}> = {}) {
+  const userId = overrides.userId ?? salesUser.id
+  return {
+    id: overrides.id ?? 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    userId,
+    reportDate: overrides.reportDate ?? new Date('2026-04-18'),
+    problem: '課題テキスト',
+    plan: '翌日予定テキスト',
+    createdAt: new Date('2026-04-18T09:00:00.000Z'),
+    updatedAt: new Date('2026-04-18T09:00:00.000Z'),
+    user: {
+      id: userId,
+      name: overrides.userName ?? salesUser.name,
+    },
+    visitRecords: [
+      {
+        id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        content: '商談内容',
+        sortOrder: 1,
+        customer: {
+          id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          name: '佐藤 健',
+          company: '株式会社A',
+        },
+      },
+    ],
+    _count: { comments: 0 },
+  }
+}
+
+const defaultQuery = { page: 1, per_page: 20 } as const
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('listReports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Role-based scoping ────────────────────────────────────────────────────
+
+  describe('ロールによるスコープ制御', () => {
+    it('salesロールは常に自分のuserId でフィルタされる', async () => {
+      mockCount.mockResolvedValueOnce(1)
+      mockFindMany.mockResolvedValueOnce([makePrismaReport()])
+
+      await listReports(salesUser, defaultQuery)
+
+      expect(mockCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ userId: salesUser.id }) }),
+      )
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ userId: salesUser.id }) }),
+      )
+    })
+
+    it('salesロールにuser_idクエリを渡してもスコープは本人IDに固定される', async () => {
+      mockCount.mockResolvedValueOnce(0)
+      mockFindMany.mockResolvedValueOnce([])
+
+      await listReports(salesUser, { ...defaultQuery, user_id: salesUser2.id })
+
+      // user_id クエリは無視され、where.userId は本人IDになる
+      expect(mockCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: salesUser.id } }),
+      )
+    })
+
+    it('managerロールはuser_idフィルタなしで全件取得できる（userIdフィルタなし）', async () => {
+      mockCount.mockResolvedValueOnce(2)
+      mockFindMany.mockResolvedValueOnce([
+        makePrismaReport(),
+        makePrismaReport({ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', userId: salesUser2.id }),
+      ])
+
+      await listReports(managerUser, defaultQuery)
+
+      // userId フィルタが付かないこと
+      expect(mockCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {} }),
+      )
+    })
+
+    it('managerロールにuser_idを指定するとそのIDでフィルタされる', async () => {
+      mockCount.mockResolvedValueOnce(1)
+      mockFindMany.mockResolvedValueOnce([makePrismaReport()])
+
+      await listReports(managerUser, { ...defaultQuery, user_id: salesUser.id })
+
+      expect(mockCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ userId: salesUser.id }) }),
+      )
+    })
+
+    it('adminロールはuser_idフィルタなしで全件取得できる', async () => {
+      mockCount.mockResolvedValueOnce(1)
+      mockFindMany.mockResolvedValueOnce([makePrismaReport()])
+
+      await listReports(adminUser, defaultQuery)
+
+      expect(mockCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {} }),
+      )
+    })
+  })
+
+  // ── Date range filters ────────────────────────────────────────────────────
+
+  describe('日付フィルタ', () => {
+    it('date_fromを指定するとreportDate.gteに設定される', async () => {
+      mockCount.mockResolvedValueOnce(0)
+      mockFindMany.mockResolvedValueOnce([])
+
+      await listReports(managerUser, { ...defaultQuery, date_from: '2026-04-01' })
+
+      expect(mockCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            reportDate: expect.objectContaining({ gte: new Date('2026-04-01') }),
+          }),
+        }),
+      )
+    })
+
+    it('date_toを指定するとreportDate.lteに設定される', async () => {
+      mockCount.mockResolvedValueOnce(0)
+      mockFindMany.mockResolvedValueOnce([])
+
+      await listReports(managerUser, { ...defaultQuery, date_to: '2026-04-18' })
+
+      expect(mockCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            reportDate: expect.objectContaining({ lte: new Date('2026-04-18') }),
+          }),
+        }),
+      )
+    })
+
+    it('date_fromとdate_toを両方指定するとgte/lteが両方設定される', async () => {
+      mockCount.mockResolvedValueOnce(0)
+      mockFindMany.mockResolvedValueOnce([])
+
+      await listReports(managerUser, {
+        ...defaultQuery,
+        date_from: '2026-04-01',
+        date_to: '2026-04-30',
+      })
+
+      expect(mockCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            reportDate: {
+              gte: new Date('2026-04-01'),
+              lte: new Date('2026-04-30'),
+            },
+          }),
+        }),
+      )
+    })
+
+    it('日付フィルタなしの場合はreportDateフィルタが設定されない', async () => {
+      mockCount.mockResolvedValueOnce(0)
+      mockFindMany.mockResolvedValueOnce([])
+
+      await listReports(salesUser, defaultQuery)
+
+      // where に reportDate が含まれないこと
+      const calledArgs = mockCount.mock.calls[0]?.[0]
+      const calledWhere = (calledArgs?.where ?? {}) as Record<string, unknown>
+      expect(calledWhere).not.toHaveProperty('reportDate')
+    })
+  })
+
+  // ── Pagination ────────────────────────────────────────────────────────────
+
+  describe('ページネーション', () => {
+    it('page=2, per_page=10のとき skip=10, take=10 でfindManyが呼ばれる', async () => {
+      mockCount.mockResolvedValueOnce(25)
+      mockFindMany.mockResolvedValueOnce([])
+
+      await listReports(managerUser, { page: 2, per_page: 10 })
+
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 10, take: 10 }),
+      )
+    })
+
+    it('page=1, per_page=20（デフォルト）のとき skip=0, take=20 でfindManyが呼ばれる', async () => {
+      mockCount.mockResolvedValueOnce(0)
+      mockFindMany.mockResolvedValueOnce([])
+
+      await listReports(salesUser, defaultQuery)
+
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 20 }),
+      )
+    })
+
+    it('レスポンスのmetaにtotal・page・per_pageが反映される', async () => {
+      mockCount.mockResolvedValueOnce(45)
+      mockFindMany.mockResolvedValueOnce([])
+
+      const result = await listReports(managerUser, { page: 3, per_page: 10 })
+
+      expect(result.meta).toEqual({ total: 45, page: 3, per_page: 10 })
+    })
+  })
+
+  // ── Response shape ────────────────────────────────────────────────────────
+
+  describe('レスポンス形式', () => {
+    it('report_dateがYYYY-MM-DD形式の文字列に変換される', async () => {
+      mockCount.mockResolvedValueOnce(1)
+      mockFindMany.mockResolvedValueOnce([makePrismaReport({ reportDate: new Date('2026-04-18') })])
+
+      const result = await listReports(salesUser, defaultQuery)
+
+      expect(result.data[0].report_date).toBe('2026-04-18')
+    })
+
+    it('visit_recordsにcustomer情報とsort_orderが含まれる', async () => {
+      mockCount.mockResolvedValueOnce(1)
+      mockFindMany.mockResolvedValueOnce([makePrismaReport()])
+
+      const result = await listReports(salesUser, defaultQuery)
+
+      const vr = result.data[0].visit_records[0]
+      expect(vr.customer.id).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc')
+      expect(vr.customer.name).toBe('佐藤 健')
+      expect(vr.customer.company).toBe('株式会社A')
+      expect(vr.content).toBe('商談内容')
+      expect(vr.sort_order).toBe(1)
+    })
+
+    it('comments_countが_count.commentsから正しくマッピングされる', async () => {
+      const reportWithComments = makePrismaReport()
+      reportWithComments._count.comments = 3
+
+      mockCount.mockResolvedValueOnce(1)
+      mockFindMany.mockResolvedValueOnce([reportWithComments])
+
+      const result = await listReports(managerUser, defaultQuery)
+
+      expect(result.data[0].comments_count).toBe(3)
+    })
+
+    it('created_atとupdated_atがISO 8601文字列に変換される', async () => {
+      mockCount.mockResolvedValueOnce(1)
+      mockFindMany.mockResolvedValueOnce([makePrismaReport()])
+
+      const result = await listReports(salesUser, defaultQuery)
+
+      expect(result.data[0].created_at).toBe('2026-04-18T09:00:00.000Z')
+      expect(result.data[0].updated_at).toBe('2026-04-18T09:00:00.000Z')
+    })
+
+    it('件数が0件の場合はdataが空配列でtotal=0が返る', async () => {
+      mockCount.mockResolvedValueOnce(0)
+      mockFindMany.mockResolvedValueOnce([])
+
+      const result = await listReports(salesUser, defaultQuery)
+
+      expect(result.data).toEqual([])
+      expect(result.meta.total).toBe(0)
+    })
+
+    it('findManyはreportDateの降順で呼ばれる', async () => {
+      mockCount.mockResolvedValueOnce(0)
+      mockFindMany.mockResolvedValueOnce([])
+
+      await listReports(managerUser, defaultQuery)
+
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({ orderBy: { reportDate: 'desc' } }),
+      )
+    })
+  })
+})

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -1,0 +1,125 @@
+import { prisma } from '@/lib/prisma'
+import type { AuthUser } from '@/types'
+import type { ListReportsQuery } from '@/lib/schemas/report.schema'
+
+export interface ReportListItem {
+  id: string
+  report_date: string
+  problem: string
+  plan: string
+  user: {
+    id: string
+    name: string
+  }
+  visit_records: {
+    id: string
+    customer: {
+      id: string
+      name: string
+      company: string | null
+    }
+    content: string
+    sort_order: number
+  }[]
+  comments_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ListReportsResult {
+  data: ReportListItem[]
+  meta: {
+    total: number
+    page: number
+    per_page: number
+  }
+}
+
+export async function listReports(
+  user: AuthUser,
+  query: ListReportsQuery,
+): Promise<ListReportsResult> {
+  const { page, per_page, user_id, date_from, date_to } = query
+  const skip = (page - 1) * per_page
+
+  // Build the WHERE clause based on role
+  const where: {
+    userId?: string
+    reportDate?: { gte?: Date; lte?: Date }
+  } = {}
+
+  // sales role: always scoped to own reports; user_id filter is ignored
+  if (user.role === 'sales') {
+    where.userId = user.id
+  } else if (user_id) {
+    // manager/admin: user_id filter is effective
+    where.userId = user_id
+  }
+
+  // Date range filters
+  if (date_from || date_to) {
+    where.reportDate = {}
+    if (date_from) {
+      where.reportDate.gte = new Date(date_from)
+    }
+    if (date_to) {
+      // Include the full day of date_to
+      where.reportDate.lte = new Date(date_to)
+    }
+  }
+
+  const [total, reports] = await Promise.all([
+    prisma.dailyReport.count({ where }),
+    prisma.dailyReport.findMany({
+      where,
+      skip,
+      take: per_page,
+      orderBy: { reportDate: 'desc' },
+      include: {
+        user: {
+          select: { id: true, name: true },
+        },
+        visitRecords: {
+          orderBy: { sortOrder: 'asc' },
+          include: {
+            customer: {
+              select: { id: true, name: true, company: true },
+            },
+          },
+        },
+        _count: {
+          select: { comments: true },
+        },
+      },
+    }),
+  ])
+
+  const data: ReportListItem[] = reports.map((report) => ({
+    id: report.id,
+    report_date: report.reportDate.toISOString().slice(0, 10),
+    problem: report.problem,
+    plan: report.plan,
+    user: {
+      id: report.user.id,
+      name: report.user.name,
+    },
+    visit_records: report.visitRecords.map((vr) => ({
+      id: vr.id,
+      customer: {
+        id: vr.customer.id,
+        name: vr.customer.name,
+        company: vr.customer.company,
+      },
+      content: vr.content,
+      sort_order: vr.sortOrder,
+    })),
+    comments_count: report._count.comments,
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  }))
+
+  return {
+    data,
+    meta: { total, page, per_page },
+  }
+}

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -63,7 +63,7 @@ export async function listReports(
       where.reportDate.gte = new Date(date_from)
     }
     if (date_to) {
-      // Include the full day of date_to
+      // reportDate is @db.Date (date-only), so lte comparison works at date level
       where.reportDate.lte = new Date(date_to)
     }
   }

--- a/src/lib/schemas/report.schema.ts
+++ b/src/lib/schemas/report.schema.ts
@@ -49,5 +49,37 @@ export const createReportSchema = reportBaseSchema.extend({
 
 export const updateReportSchema = reportBaseSchema
 
+export const listReportsQuerySchema = z.object({
+  user_id: z
+    .string()
+    .uuid('user_idはUUID形式で入力してください')
+    .optional(),
+  date_from: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'date_fromはYYYY-MM-DD形式で入力してください')
+    .optional(),
+  date_to: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'date_toはYYYY-MM-DD形式で入力してください')
+    .optional(),
+  page: z
+    .string()
+    .optional()
+    .transform((val) => (val !== undefined ? parseInt(val, 10) : 1))
+    .pipe(z.number().int().min(1, 'pageは1以上の整数で入力してください')),
+  per_page: z
+    .string()
+    .optional()
+    .transform((val) => (val !== undefined ? parseInt(val, 10) : 20))
+    .pipe(
+      z
+        .number()
+        .int()
+        .min(1, 'per_pageは1以上の整数で入力してください')
+        .max(100, 'per_pageは100以下の整数で入力してください'),
+    ),
+})
+
 export type CreateReportInput = z.infer<typeof createReportSchema>
 export type UpdateReportInput = z.infer<typeof updateReportSchema>
+export type ListReportsQuery = z.infer<typeof listReportsQuerySchema>

--- a/src/lib/schemas/report.schema.ts
+++ b/src/lib/schemas/report.schema.ts
@@ -57,10 +57,18 @@ export const listReportsQuerySchema = z.object({
   date_from: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, 'date_fromはYYYY-MM-DD形式で入力してください')
+    .refine((val) => {
+      const date = new Date(val)
+      return !isNaN(date.getTime()) && date.toISOString().slice(0, 10) === val
+    }, 'date_fromに存在しない日付は指定できません')
     .optional(),
   date_to: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, 'date_toはYYYY-MM-DD形式で入力してください')
+    .refine((val) => {
+      const date = new Date(val)
+      return !isNaN(date.getTime()) && date.toISOString().slice(0, 10) === val
+    }, 'date_toに存在しない日付は指定できません')
     .optional(),
   page: z
     .string()


### PR DESCRIPTION
## Summary
- `GET /reports` エンドポイントを実装
- `sales` ロールは自分の日報のみ取得、`manager`/`admin` は全ユーザー分取得
- `user_id`・`date_from`・`date_to` フィルタ、ページネーション対応
- `visit_records` + `customer` JOIN、`comments_count` 集計
- Zod によるクエリパラメータバリデーション

## Test plan
- [ ] API-011: `sales` ユーザーは自分の日報のみ返される
- [ ] API-012: `manager` ユーザーは全ユーザーの日報が返される
- [ ] API-013: `user_id` フィルタで指定ユーザーの日報のみ返される
- [ ] `sales` ユーザーが `user_id` フィルタを指定しても自分の日報のみ返される
- [ ] `date_from`/`date_to` フィルタで日付範囲絞り込みが動作する
- [ ] ページネーション (`page`, `per_page`) が正しく動作する
- [ ] 未認証リクエストは 401 を返す
- [ ] Vitest: 199/199 テスト通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)