### PR TITLE
feat: GET /reports/:id 日報詳細API実装 (closes #9)

### DIFF
--- a/src/app/api/reports/[id]/route.test.ts
+++ b/src/app/api/reports/[id]/route.test.ts
@@ -207,6 +207,16 @@ describe('GET /api/reports/:id', () => {
       expect(res.status).toBe(404)
       expect(body.error.code).toBe('NOT_FOUND')
     })
+
+    it('UUID形式でないIDを指定すると404を返す（Prismaエラーを回避）', async () => {
+      const req = makeRequest(salesUser, 'not-a-uuid')
+      const res = await GET(req, makeContext('not-a-uuid'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockGetReport).not.toHaveBeenCalled()
+    })
   })
 
   // ── RPT-021: salesユーザーが自分の日報を取得 → 200 ─────────────────────────

--- a/src/app/api/reports/[id]/route.test.ts
+++ b/src/app/api/reports/[id]/route.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+import * as reportsService from '@/lib/reports/reports.service'
+import { generateToken } from '@/lib/auth/jwt'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+import type { ReportDetail } from '@/lib/reports/reports.service'
+
+vi.mock('@/lib/reports/reports.service', () => ({
+  listReports: vi.fn(),
+  getReport: vi.fn(),
+}))
+
+// Mock the blacklist so tokens are never invalidated in tests
+vi.mock('@/lib/auth/blacklist', () => ({
+  isBlacklisted: vi.fn().mockReturnValue(false),
+}))
+
+const mockGetReport = vi.mocked(reportsService.getReport)
+
+// ─── Test users ───────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const salesUser2: AuthUser = {
+  id: '22222222-2222-2222-2222-222222222222',
+  name: '鈴木 一郎',
+  email: 'suzuki@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample data ──────────────────────────────────────────────────────────────
+
+const REPORT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+const sampleReportDetail: ReportDetail = {
+  id: REPORT_ID,
+  report_date: '2026-04-19',
+  problem: '課題テキスト',
+  plan: '翌日予定テキスト',
+  user: {
+    id: salesUser.id,
+    name: salesUser.name,
+    role: 'sales',
+  },
+  visit_records: [
+    {
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      customer: {
+        id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        name: '佐藤 健',
+        company: '株式会社A',
+      },
+      content: '商談内容',
+      sort_order: 1,
+    },
+  ],
+  comments: [
+    {
+      id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      body: 'コメント本文',
+      commenter: {
+        id: managerUser.id,
+        name: managerUser.name,
+      },
+      created_at: '2026-04-19T18:32:00.000Z',
+    },
+  ],
+  created_at: '2026-04-19T09:00:00.000Z',
+  updated_at: '2026-04-19T09:00:00.000Z',
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(user: AuthUser, reportId = REPORT_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+    },
+  })
+}
+
+function makeRequestWithoutAuth(reportId = REPORT_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}`, {
+    method: 'GET',
+  })
+}
+
+function makeContext(reportId = REPORT_ID): Record<string, unknown> {
+  return { params: { id: reportId } }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/reports/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Authentication ──────────────────────────────────────────────────────────
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = makeRequestWithoutAuth()
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  // ── API-017: 存在するID → 200, data に全フィールド含む ──────────────────────
+
+  describe('API-017: 存在する日報IDを指定すると全フィールドを含む200レスポンスを返す', () => {
+    it('200とdataに全フィールドが含まれること', async () => {
+      mockGetReport.mockResolvedValueOnce(sampleReportDetail)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data.id).toBe(REPORT_ID)
+      expect(body.data.report_date).toBe('2026-04-19')
+      expect(body.data.problem).toBe('課題テキスト')
+      expect(body.data.plan).toBe('翌日予定テキスト')
+      expect(body.data.created_at).toBe('2026-04-19T09:00:00.000Z')
+      expect(body.data.updated_at).toBe('2026-04-19T09:00:00.000Z')
+    })
+
+    it('userフィールドにid・name・roleが含まれること', async () => {
+      mockGetReport.mockResolvedValueOnce(sampleReportDetail)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(body.data.user.id).toBe(salesUser.id)
+      expect(body.data.user.name).toBe(salesUser.name)
+      expect(body.data.user.role).toBe('sales')
+    })
+
+    it('visit_recordsにcustomer情報・content・sort_orderが含まれること', async () => {
+      mockGetReport.mockResolvedValueOnce(sampleReportDetail)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      const vr = body.data.visit_records[0]
+      expect(vr.id).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+      expect(vr.customer.id).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc')
+      expect(vr.customer.name).toBe('佐藤 健')
+      expect(vr.customer.company).toBe('株式会社A')
+      expect(vr.content).toBe('商談内容')
+      expect(vr.sort_order).toBe(1)
+    })
+
+    it('commentsにid・body・commenter・created_atが含まれること', async () => {
+      mockGetReport.mockResolvedValueOnce(sampleReportDetail)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      const comment = body.data.comments[0]
+      expect(comment.id).toBe('dddddddd-dddd-dddd-dddd-dddddddddddd')
+      expect(comment.body).toBe('コメント本文')
+      expect(comment.commenter.id).toBe(managerUser.id)
+      expect(comment.commenter.name).toBe(managerUser.name)
+      expect(comment.created_at).toBe('2026-04-19T18:32:00.000Z')
+    })
+  })
+
+  // ── API-018: 存在しないID → 404 NOT_FOUND ──────────────────────────────────
+
+  describe('API-018: 存在しない日報IDを指定すると404を返す', () => {
+    it('存在しないIDに対して404とNOT_FOUNDコードを返す', async () => {
+      mockGetReport.mockRejectedValueOnce(AppError.notFound('日報'))
+
+      const req = makeRequest(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
+      const res = await GET(req, makeContext('ffffffff-ffff-ffff-ffff-ffffffffffff'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+  })
+
+  // ── RPT-021: salesユーザーが自分の日報を取得 → 200 ─────────────────────────
+
+  describe('RPT-021: salesユーザーは自分の日報を取得できる', () => {
+    it('自分の日報に対して200を返す', async () => {
+      mockGetReport.mockResolvedValueOnce(sampleReportDetail)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data.user.id).toBe(salesUser.id)
+      expect(mockGetReport).toHaveBeenCalledWith(salesUser, REPORT_ID)
+    })
+  })
+
+  // ── RPT-022: managerが任意の日報を取得 → 200 ─────────────────────────────
+
+  describe('RPT-022: managerは任意の日報を取得できる', () => {
+    it('他のユーザーの日報に対して200を返す', async () => {
+      mockGetReport.mockResolvedValueOnce(sampleReportDetail)
+
+      const req = makeRequest(managerUser)
+      const res = await GET(req, makeContext())
+
+      expect(res.status).toBe(200)
+      expect(mockGetReport).toHaveBeenCalledWith(managerUser, REPORT_ID)
+    })
+  })
+
+  // ── SEC-003: salesユーザーが他人の日報を取得 → 403 FORBIDDEN ──────────────
+
+  describe('SEC-003: salesユーザーが他人の日報を取得しようとすると403を返す', () => {
+    it('他人の日報に対して403とFORBIDDENコードを返す', async () => {
+      mockGetReport.mockRejectedValueOnce(AppError.forbidden())
+
+      const req = makeRequest(salesUser2)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ── adminが任意の日報を取得 → 200 ────────────────────────────────────────
+
+  describe('adminは任意の日報を取得できる', () => {
+    it('adminユーザーで200を返す', async () => {
+      mockGetReport.mockResolvedValueOnce(sampleReportDetail)
+
+      const req = makeRequest(adminUser)
+      const res = await GET(req, makeContext())
+
+      expect(res.status).toBe(200)
+      expect(mockGetReport).toHaveBeenCalledWith(adminUser, REPORT_ID)
+    })
+  })
+
+  // ── visit_records が sort_order 昇順で返る ────────────────────────────────
+
+  describe('visit_records は sort_order 昇順で返る', () => {
+    it('sort_orderが昇順に並んだvisit_recordsを返す', async () => {
+      const detailWithMultipleVR: ReportDetail = {
+        ...sampleReportDetail,
+        visit_records: [
+          {
+            id: 'vr-001',
+            customer: { id: 'cust-001', name: '顧客A', company: null },
+            content: '内容1',
+            sort_order: 1,
+          },
+          {
+            id: 'vr-002',
+            customer: { id: 'cust-002', name: '顧客B', company: '会社B' },
+            content: '内容2',
+            sort_order: 2,
+          },
+          {
+            id: 'vr-003',
+            customer: { id: 'cust-003', name: '顧客C', company: null },
+            content: '内容3',
+            sort_order: 3,
+          },
+        ],
+      }
+      mockGetReport.mockResolvedValueOnce(detailWithMultipleVR)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(body.data.visit_records).toHaveLength(3)
+      expect(body.data.visit_records[0].sort_order).toBe(1)
+      expect(body.data.visit_records[1].sort_order).toBe(2)
+      expect(body.data.visit_records[2].sort_order).toBe(3)
+    })
+  })
+
+  // ── comments が created_at 昇順で含まれる ─────────────────────────────────
+
+  describe('comments は created_at 昇順で含まれる', () => {
+    it('created_atが昇順に並んだcommentsを返す', async () => {
+      const detailWithMultipleComments: ReportDetail = {
+        ...sampleReportDetail,
+        comments: [
+          {
+            id: 'comment-001',
+            body: '最初のコメント',
+            commenter: { id: managerUser.id, name: managerUser.name },
+            created_at: '2026-04-19T10:00:00.000Z',
+          },
+          {
+            id: 'comment-002',
+            body: '2番目のコメント',
+            commenter: { id: managerUser.id, name: managerUser.name },
+            created_at: '2026-04-19T11:00:00.000Z',
+          },
+          {
+            id: 'comment-003',
+            body: '3番目のコメント',
+            commenter: { id: adminUser.id, name: adminUser.name },
+            created_at: '2026-04-19T12:00:00.000Z',
+          },
+        ],
+      }
+      mockGetReport.mockResolvedValueOnce(detailWithMultipleComments)
+
+      const req = makeRequest(managerUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(body.data.comments).toHaveLength(3)
+      expect(body.data.comments[0].created_at).toBe('2026-04-19T10:00:00.000Z')
+      expect(body.data.comments[1].created_at).toBe('2026-04-19T11:00:00.000Z')
+      expect(body.data.comments[2].created_at).toBe('2026-04-19T12:00:00.000Z')
+    })
+  })
+
+  // ── Error handling ────────────────────────────────────────────────────────
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockGetReport.mockRejectedValueOnce(new Error('Database connection failed'))
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { withAuth } from '@/lib/auth/guard'
 import { getReport } from '@/lib/reports/reports.service'
 import { handleError } from '@/lib/errors'
+import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 async function handleGetReport(
   _req: NextRequest,
@@ -12,6 +15,10 @@ async function handleGetReport(
   try {
     const params = await (context.params as Promise<{ id: string }>)
     const reportId = params.id
+
+    if (!UUID_REGEX.test(reportId)) {
+      throw AppError.notFound('日報')
+    }
 
     const data = await getReport(user, reportId)
     return NextResponse.json({ data })

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/guard'
+import { getReport } from '@/lib/reports/reports.service'
+import { handleError } from '@/lib/errors'
+import type { AuthUser } from '@/types'
+
+async function handleGetReport(
+  _req: NextRequest,
+  context: Record<string, unknown>,
+  user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const params = context.params as { id: string }
+    const reportId = params.id
+
+    const data = await getReport(user, reportId)
+    return NextResponse.json({ data })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const GET = withAuth(handleGetReport)

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -10,7 +10,7 @@ async function handleGetReport(
   user: AuthUser,
 ): Promise<NextResponse> {
   try {
-    const params = context.params as { id: string }
+    const params = await (context.params as Promise<{ id: string }>)
     const reportId = params.id
 
     const data = await getReport(user, reportId)

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listReports } from './reports.service'
+import { listReports, getReport } from './reports.service'
 import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
 
 vi.mock('@/lib/prisma', () => ({
@@ -8,12 +9,14 @@ vi.mock('@/lib/prisma', () => ({
     dailyReport: {
       count: vi.fn(),
       findMany: vi.fn(),
+      findUnique: vi.fn(),
     },
   },
 }))
 
 const mockCount = vi.mocked(prisma.dailyReport.count)
 const mockFindMany = vi.mocked(prisma.dailyReport.findMany)
+const mockFindUnique = vi.mocked(prisma.dailyReport.findUnique)
 
 // ─── Test users ───────────────────────────────────────────────────────────────
 
@@ -327,6 +330,205 @@ describe('listReports', () => {
 
       expect(mockFindMany).toHaveBeenCalledWith(
         expect.objectContaining({ orderBy: { reportDate: 'desc' } }),
+      )
+    })
+  })
+})
+
+// ─── getReport tests ──────────────────────────────────────────────────────────
+
+function makePrismaReportDetail(overrides: Partial<{
+  id: string
+  userId: string
+  reportDate: Date
+}> = {}) {
+  const userId = overrides.userId ?? salesUser.id
+  return {
+    id: overrides.id ?? 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    userId,
+    reportDate: overrides.reportDate ?? new Date('2026-04-19'),
+    problem: '課題テキスト',
+    plan: '翌日予定テキスト',
+    createdAt: new Date('2026-04-19T09:00:00.000Z'),
+    updatedAt: new Date('2026-04-19T09:00:00.000Z'),
+    user: {
+      id: userId,
+      name: salesUser.name,
+      role: 'sales' as const,
+    },
+    visitRecords: [
+      {
+        id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        content: '商談内容',
+        sortOrder: 1,
+        customer: {
+          id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          name: '佐藤 健',
+          company: '株式会社A',
+        },
+      },
+    ],
+    comments: [
+      {
+        id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        body: 'コメント本文',
+        createdAt: new Date('2026-04-19T18:32:00.000Z'),
+        commenter: {
+          id: managerUser.id,
+          name: managerUser.name,
+        },
+      },
+    ],
+  }
+}
+
+describe('getReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Not found ─────────────────────────────────────────────────────────────
+
+  describe('存在しないID', () => {
+    it('存在しないIDに対してAppError(NOT_FOUND)をスローする', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+
+      await expect(
+        getReport(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+      ).rejects.toThrow(AppError)
+
+      await expect(
+        getReport(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    })
+  })
+
+  // ── Role-based access control ─────────────────────────────────────────────
+
+  describe('アクセス制御', () => {
+    it('salesユーザーは自分の日報を取得できる', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail({ userId: salesUser.id }))
+
+      const result = await getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      expect(result.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+      expect(result.user.id).toBe(salesUser.id)
+    })
+
+    it('salesユーザーが他人の日報を取得しようとするとAppError(FORBIDDEN)をスローする', async () => {
+      // Report belongs to salesUser2, but salesUser is the requester
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail({ userId: salesUser2.id }))
+
+      await expect(
+        getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    })
+
+    it('managerは他のユーザーの日報を取得できる', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail({ userId: salesUser.id }))
+
+      const result = await getReport(managerUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      expect(result.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    })
+
+    it('adminは他のユーザーの日報を取得できる', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail({ userId: salesUser.id }))
+
+      const result = await getReport(adminUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      expect(result.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    })
+  })
+
+  // ── Response shape ────────────────────────────────────────────────────────
+
+  describe('レスポンス形式', () => {
+    it('report_dateがYYYY-MM-DD形式の文字列に変換される', async () => {
+      mockFindUnique.mockResolvedValueOnce(
+        makePrismaReportDetail({ reportDate: new Date('2026-04-19') }),
+      )
+
+      const result = await getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      expect(result.report_date).toBe('2026-04-19')
+    })
+
+    it('userフィールドにid・name・roleが含まれる', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail())
+
+      const result = await getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      expect(result.user.id).toBe(salesUser.id)
+      expect(result.user.name).toBe(salesUser.name)
+      expect(result.user.role).toBe('sales')
+    })
+
+    it('visit_recordsにcustomer情報・content・sort_orderが含まれる', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail())
+
+      const result = await getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      const vr = result.visit_records[0]
+      expect(vr.id).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+      expect(vr.customer.id).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc')
+      expect(vr.customer.name).toBe('佐藤 健')
+      expect(vr.customer.company).toBe('株式会社A')
+      expect(vr.content).toBe('商談内容')
+      expect(vr.sort_order).toBe(1)
+    })
+
+    it('commentsにid・body・commenter・created_atが含まれる', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail())
+
+      const result = await getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      const comment = result.comments[0]
+      expect(comment.id).toBe('dddddddd-dddd-dddd-dddd-dddddddddddd')
+      expect(comment.body).toBe('コメント本文')
+      expect(comment.commenter.id).toBe(managerUser.id)
+      expect(comment.commenter.name).toBe(managerUser.name)
+      expect(comment.created_at).toBe('2026-04-19T18:32:00.000Z')
+    })
+
+    it('created_atとupdated_atがISO 8601文字列に変換される', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail())
+
+      const result = await getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      expect(result.created_at).toBe('2026-04-19T09:00:00.000Z')
+      expect(result.updated_at).toBe('2026-04-19T09:00:00.000Z')
+    })
+
+    it('visit_recordsをsortOrder昇順で取得するクエリが発行される', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail())
+
+      await getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      expect(mockFindUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: expect.objectContaining({
+            visitRecords: expect.objectContaining({
+              orderBy: { sortOrder: 'asc' },
+            }),
+          }),
+        }),
+      )
+    })
+
+    it('commentsをcreatedAt昇順で取得するクエリが発行される', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaReportDetail())
+
+      await getReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+      expect(mockFindUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: expect.objectContaining({
+            comments: expect.objectContaining({
+              orderBy: { createdAt: 'asc' },
+            }),
+          }),
+        }),
       )
     })
   })

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -391,7 +391,7 @@ describe('getReport', () => {
 
   describe('存在しないID', () => {
     it('存在しないIDに対してAppError(NOT_FOUND)をスローする', async () => {
-      mockFindUnique.mockResolvedValueOnce(null)
+      mockFindUnique.mockResolvedValue(null)
 
       await expect(
         getReport(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
-import type { AuthUser } from '@/types'
+import type { AuthUser, UserRole } from '@/types'
 import type { ListReportsQuery } from '@/lib/schemas/report.schema'
 
 export interface ReportListItem {
@@ -44,7 +44,7 @@ export interface ReportDetail {
   user: {
     id: string
     name: string
-    role: string
+    role: UserRole
   }
   visit_records: {
     id: string

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
 import type { ListReportsQuery } from '@/lib/schemas/report.schema'
 
@@ -33,6 +34,39 @@ export interface ListReportsResult {
     page: number
     per_page: number
   }
+}
+
+export interface ReportDetail {
+  id: string
+  report_date: string
+  problem: string
+  plan: string
+  user: {
+    id: string
+    name: string
+    role: string
+  }
+  visit_records: {
+    id: string
+    customer: {
+      id: string
+      name: string
+      company: string | null
+    }
+    content: string
+    sort_order: number
+  }[]
+  comments: {
+    id: string
+    body: string
+    commenter: {
+      id: string
+      name: string
+    }
+    created_at: string
+  }[]
+  created_at: string
+  updated_at: string
 }
 
 export async function listReports(
@@ -121,5 +155,74 @@ export async function listReports(
   return {
     data,
     meta: { total, page, per_page },
+  }
+}
+
+export async function getReport(user: AuthUser, reportId: string): Promise<ReportDetail> {
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    include: {
+      user: {
+        select: { id: true, name: true, role: true },
+      },
+      visitRecords: {
+        orderBy: { sortOrder: 'asc' },
+        include: {
+          customer: {
+            select: { id: true, name: true, company: true },
+          },
+        },
+      },
+      comments: {
+        orderBy: { createdAt: 'asc' },
+        include: {
+          commenter: {
+            select: { id: true, name: true },
+          },
+        },
+      },
+    },
+  })
+
+  if (!report) {
+    throw AppError.notFound('日報')
+  }
+
+  // sales role can only view their own reports
+  if (user.role === 'sales' && report.userId !== user.id) {
+    throw AppError.forbidden()
+  }
+
+  return {
+    id: report.id,
+    report_date: report.reportDate.toISOString().slice(0, 10),
+    problem: report.problem,
+    plan: report.plan,
+    user: {
+      id: report.user.id,
+      name: report.user.name,
+      role: report.user.role,
+    },
+    visit_records: report.visitRecords.map((vr) => ({
+      id: vr.id,
+      customer: {
+        id: vr.customer.id,
+        name: vr.customer.name,
+        company: vr.customer.company,
+      },
+      content: vr.content,
+      sort_order: vr.sortOrder,
+    })),
+    comments: report.comments.map((c) => ({
+      id: c.id,
+      body: c.body,
+      commenter: {
+        id: c.commenter.id,
+        name: c.commenter.name,
+      },
+      created_at: c.createdAt.toISOString(),
+    })),
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
   }
 }


### PR DESCRIPTION
## Summary

- `GET /reports/:id` エンドポイントを実装（認証必要・全ロール）
- `getReport` サービス関数を `reports.service.ts` に追加
- アクセス制御: `sales` は自分の日報のみ、`manager`/`admin` は全日報を閲覧可能
- レスポンスに `user`（id・name・role）、`visit_records`（sort_order昇順）、`comments`（created_at昇順）を含む
- 存在しないIDは 404 NOT_FOUND、他人の日報への sales アクセスは 403 FORBIDDEN

## Test plan

- [x] API-017: 存在するID → 200、data に全フィールド含む（id、report_date、problem、plan、user、visit_records、comments、created_at、updated_at）
- [x] API-018: 存在しないID → 404 NOT_FOUND
- [x] RPT-021: salesユーザーが自分の日報を取得 → 200
- [x] RPT-022: managerが任意の日報を取得 → 200
- [x] SEC-003: salesユーザーが他人の日報を取得 → 403 FORBIDDEN
- [x] adminが任意の日報を取得 → 200
- [x] 認証なし → 401 UNAUTHORIZED
- [x] visit_records が sort_order 昇順で返る
- [x] comments が created_at 昇順で含まれる
- [x] サービス層 `getReport` 単体テスト（NOT_FOUND、FORBIDDEN、レスポンス形式、クエリ順序）

🤖 Generated with [Claude Code](https://claude.com/claude-code)