### PR TITLE
feat: POST /reports - 日報作成API実装 (closes #8)

### DIFF
--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -5,7 +5,7 @@ import * as reportsService from '@/lib/reports/reports.service'
 import { generateToken } from '@/lib/auth/jwt'
 import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
-import type { ListReportsResult, ReportDetail } from '@/lib/reports/reports.service'
+import type { ListReportsResult, CreateReportResult } from '@/lib/reports/reports.service'
 
 vi.mock('@/lib/reports/reports.service', () => ({
   listReports: vi.fn(),
@@ -532,7 +532,7 @@ const validBody = {
   ],
 }
 
-const createdReport: ReportDetail = {
+const createdReport: CreateReportResult = {
   id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
   report_date: '2026-04-18',
   problem: '課題テキスト',

--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
-import { GET } from './route'
+import { GET, POST } from './route'
 import * as reportsService from '@/lib/reports/reports.service'
 import { generateToken } from '@/lib/auth/jwt'
 import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
-import type { ListReportsResult } from '@/lib/reports/reports.service'
+import type { ListReportsResult, ReportDetail } from '@/lib/reports/reports.service'
 
 vi.mock('@/lib/reports/reports.service', () => ({
   listReports: vi.fn(),
+  createReport: vi.fn(),
 }))
 
 // Mock the blacklist so tokens are never invalidated in tests
@@ -17,6 +18,7 @@ vi.mock('@/lib/auth/blacklist', () => ({
 }))
 
 const mockListReports = vi.mocked(reportsService.listReports)
+const mockCreateReport = vi.mocked(reportsService.createReport)
 
 // ─── Test users ──────────────────────────────────────────────────────────────
 
@@ -511,6 +513,232 @@ describe('GET /api/reports', () => {
           date_to: '2026-04-18',
         }),
       )
+    })
+  })
+})
+
+// ─── POST /api/reports ────────────────────────────────────────────────────────
+
+const validBody = {
+  report_date: '2026-04-18',
+  problem: '課題テキスト',
+  plan: '明日やること',
+  visit_records: [
+    {
+      customer_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      content: '商談内容',
+      sort_order: 1,
+    },
+  ],
+}
+
+const createdReport: ReportDetail = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  report_date: '2026-04-18',
+  problem: '課題テキスト',
+  plan: '明日やること',
+  user: { id: salesUser.id, name: salesUser.name },
+  visit_records: [
+    {
+      id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      customer: { id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', name: '佐藤 健', company: '株式会社A' },
+      content: '商談内容',
+      sort_order: 1,
+    },
+  ],
+  comments_count: 0,
+  created_at: '2026-04-18T09:00:00.000Z',
+  updated_at: '2026-04-18T09:00:00.000Z',
+}
+
+function makePostRequest(user: AuthUser, body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/reports', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function makePostRequestWithoutAuth(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/reports', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  describe('API-014: salesロールは日報を作成できる', () => {
+    it('salesユーザーで201と作成された日報を返す', async () => {
+      mockCreateReport.mockResolvedValueOnce(createdReport)
+
+      const req = makePostRequest(salesUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(201)
+      expect(body.data.id).toBe(createdReport.id)
+      expect(body.data.report_date).toBe('2026-04-18')
+      expect(body.data.problem).toBe('課題テキスト')
+      expect(body.data.plan).toBe('明日やること')
+      expect(body.data.user.id).toBe(salesUser.id)
+      expect(body.data.visit_records).toHaveLength(1)
+      expect(body.data.comments_count).toBe(0)
+    })
+
+    it('createReportがsalesユーザーと入力で呼ばれる', async () => {
+      mockCreateReport.mockResolvedValueOnce(createdReport)
+
+      const req = makePostRequest(salesUser, validBody)
+      await POST(req, {})
+
+      expect(mockCreateReport).toHaveBeenCalledWith(
+        salesUser,
+        expect.objectContaining({
+          report_date: '2026-04-18',
+          problem: '課題テキスト',
+          plan: '明日やること',
+        }),
+      )
+    })
+  })
+
+  // ── Access control ──────────────────────────────────────────────────────────
+
+  describe('API-015: manager/adminロールは日報を作成できない', () => {
+    it('managerロールは403 FORBIDDENを返す', async () => {
+      const req = makePostRequest(managerUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+      expect(mockCreateReport).not.toHaveBeenCalled()
+    })
+
+    it('adminロールは403 FORBIDDENを返す', async () => {
+      const req = makePostRequest(adminUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+      expect(mockCreateReport).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── Authentication ──────────────────────────────────────────────────────────
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = makePostRequestWithoutAuth(validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  // ── Validation ──────────────────────────────────────────────────────────────
+
+  describe('バリデーション', () => {
+    it('visit_recordsが空配列の場合は400 VALIDATION_ERRORを返す', async () => {
+      const req = makePostRequest(salesUser, { ...validBody, visit_records: [] })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('visit_recordsが未指定の場合は400 VALIDATION_ERRORを返す', async () => {
+      const { visit_records: _omit, ...bodyWithout } = validBody
+      const req = makePostRequest(salesUser, bodyWithout)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('report_dateが未指定の場合は400 VALIDATION_ERRORを返す', async () => {
+      const { report_date: _omit, ...bodyWithout } = validBody
+      const req = makePostRequest(salesUser, bodyWithout)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('report_dateが未来日の場合は400 VALIDATION_ERRORを返す', async () => {
+      const req = makePostRequest(salesUser, { ...validBody, report_date: '2099-12-31' })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('visit_records[].contentが1001文字の場合は400 VALIDATION_ERRORを返す', async () => {
+      const req = makePostRequest(salesUser, {
+        ...validBody,
+        visit_records: [{ ...validBody.visit_records[0], content: 'a'.repeat(1001) }],
+      })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('problemが2001文字の場合は400 VALIDATION_ERRORを返す', async () => {
+      const req = makePostRequest(salesUser, { ...validBody, problem: 'a'.repeat(2001) })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // ── Business rule: duplicate ────────────────────────────────────────────────
+
+  describe('重複チェック', () => {
+    it('同じユーザー・同じ日付の日報が既に存在する場合は409 DUPLICATE_REPORTを返す', async () => {
+      mockCreateReport.mockRejectedValueOnce(AppError.duplicateReport())
+
+      const req = makePostRequest(salesUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(409)
+      expect(body.error.code).toBe('DUPLICATE_REPORT')
+    })
+  })
+
+  // ── Error handling ──────────────────────────────────────────────────────────
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockCreateReport.mockRejectedValueOnce(new Error('Database connection failed'))
+
+      const req = makePostRequest(salesUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
     })
   })
 })

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth } from '@/lib/auth/guard'
-import { listReportsQuerySchema } from '@/lib/schemas/report.schema'
-import { listReports } from '@/lib/reports/reports.service'
+import { listReportsQuerySchema, createReportSchema } from '@/lib/schemas/report.schema'
+import { listReports, createReport } from '@/lib/reports/reports.service'
 import { handleError } from '@/lib/errors'
 import type { AuthUser } from '@/types'
 
@@ -39,3 +39,20 @@ async function handleGetReports(
 }
 
 export const GET = withAuth(handleGetReports)
+
+async function handlePostReport(
+  req: NextRequest,
+  _context: Record<string, unknown>,
+  user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const body: unknown = await req.json()
+    const input = createReportSchema.parse(body)
+    const report = await createReport(user, input)
+    return NextResponse.json({ data: report }, { status: 201 })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const POST = withAuth(handlePostReport, ['sales'])

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { listReports, createReport } from './reports.service'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
+import { Prisma } from '@prisma/client'
 import type { AuthUser } from '@/types'
 
 vi.mock('@/lib/prisma', () => ({
@@ -12,14 +13,13 @@ vi.mock('@/lib/prisma', () => ({
       findUnique: vi.fn(),
       create: vi.fn(),
     },
-    $transaction: vi.fn(),
   },
 }))
 
 const mockCount = vi.mocked(prisma.dailyReport.count)
 const mockFindMany = vi.mocked(prisma.dailyReport.findMany)
 const mockFindUnique = vi.mocked(prisma.dailyReport.findUnique)
-const mockTransaction = vi.mocked(prisma.$transaction)
+const mockCreate = vi.mocked(prisma.dailyReport.create)
 
 // ─── Test users ───────────────────────────────────────────────────────────────
 
@@ -387,14 +387,10 @@ describe('createReport', () => {
   // ── Happy path ────────────────────────────────────────────────────────────
 
   describe('正常系', () => {
-    it('重複がない場合は$transactionでDailyReportとVisitRecordsを作成し結果を返す', async () => {
+    it('重複がない場合はDailyReportとVisitRecordsを作成し結果を返す', async () => {
       const prismaReport = makePrismaCreatedReport()
       mockFindUnique.mockResolvedValueOnce(null)
-      // $transaction calls the callback with a tx object — simulate by calling cb with prisma itself
-      mockTransaction.mockImplementationOnce(async (cb: (tx: typeof prisma) => Promise<unknown>) => {
-        return cb(prisma)
-      })
-      vi.mocked(prisma.dailyReport.create).mockResolvedValueOnce(prismaReport as never)
+      mockCreate.mockResolvedValueOnce(prismaReport as never)
 
       const result = await createReport(salesUser, createInput)
 
@@ -408,12 +404,8 @@ describe('createReport', () => {
     })
 
     it('findUniqueはuserId + reportDateの複合ユニークキーで呼ばれる', async () => {
-      const prismaReport = makePrismaCreatedReport()
       mockFindUnique.mockResolvedValueOnce(null)
-      mockTransaction.mockImplementationOnce(async (cb: (tx: typeof prisma) => Promise<unknown>) => {
-        return cb(prisma)
-      })
-      vi.mocked(prisma.dailyReport.create).mockResolvedValueOnce(prismaReport as never)
+      mockCreate.mockResolvedValueOnce(makePrismaCreatedReport() as never)
 
       await createReport(salesUser, createInput)
 
@@ -427,13 +419,34 @@ describe('createReport', () => {
       })
     })
 
-    it('レスポンスのvisit_recordsにcustomer情報・content・sort_orderが含まれる', async () => {
-      const prismaReport = makePrismaCreatedReport()
+    it('createにvisitRecords.createで正しくマッピングされたデータが渡される', async () => {
       mockFindUnique.mockResolvedValueOnce(null)
-      mockTransaction.mockImplementationOnce(async (cb: (tx: typeof prisma) => Promise<unknown>) => {
-        return cb(prisma)
-      })
-      vi.mocked(prisma.dailyReport.create).mockResolvedValueOnce(prismaReport as never)
+      mockCreate.mockResolvedValueOnce(makePrismaCreatedReport() as never)
+
+      await createReport(salesUser, createInput)
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: salesUser.id,
+            reportDate: new Date('2026-04-18'),
+            visitRecords: {
+              create: [
+                {
+                  customerId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+                  content: '商談内容',
+                  sortOrder: 1,
+                },
+              ],
+            },
+          }),
+        }),
+      )
+    })
+
+    it('レスポンスのvisit_recordsにcustomer情報・content・sort_orderが含まれる', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+      mockCreate.mockResolvedValueOnce(makePrismaCreatedReport() as never)
 
       const result = await createReport(salesUser, createInput)
 
@@ -447,12 +460,8 @@ describe('createReport', () => {
     })
 
     it('created_atとupdated_atがISO 8601文字列に変換される', async () => {
-      const prismaReport = makePrismaCreatedReport()
       mockFindUnique.mockResolvedValueOnce(null)
-      mockTransaction.mockImplementationOnce(async (cb: (tx: typeof prisma) => Promise<unknown>) => {
-        return cb(prisma)
-      })
-      vi.mocked(prisma.dailyReport.create).mockResolvedValueOnce(prismaReport as never)
+      mockCreate.mockResolvedValueOnce(makePrismaCreatedReport() as never)
 
       const result = await createReport(salesUser, createInput)
 
@@ -464,7 +473,7 @@ describe('createReport', () => {
   // ── Duplicate check ───────────────────────────────────────────────────────
 
   describe('重複チェック', () => {
-    it('同じuserId + reportDateの日報が既に存在する場合はAPPError DUPLICATE_REPORTをスローする', async () => {
+    it('findUniqueで重複が見つかった場合はDUPLICATE_REPORTをスローする', async () => {
       mockFindUnique.mockResolvedValueOnce(makePrismaCreatedReport() as never)
 
       await expect(createReport(salesUser, createInput)).rejects.toMatchObject({
@@ -472,12 +481,38 @@ describe('createReport', () => {
       })
     })
 
-    it('重複時は$transactionが呼ばれない', async () => {
+    it('findUniqueで重複が見つかった場合はcreateが呼ばれない', async () => {
       mockFindUnique.mockResolvedValueOnce(makePrismaCreatedReport() as never)
 
       await expect(createReport(salesUser, createInput)).rejects.toBeInstanceOf(AppError)
 
-      expect(mockTransaction).not.toHaveBeenCalled()
+      expect(mockCreate).not.toHaveBeenCalled()
+    })
+
+    it('P2002（DB unique制約違反）が発生した場合もDUPLICATE_REPORTをスローする（競合状態対応）', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+      const p2002 = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed on the fields: (`user_id`,`report_date`)',
+        { code: 'P2002', clientVersion: '5.0.0' },
+      )
+      mockCreate.mockRejectedValueOnce(p2002)
+
+      await expect(createReport(salesUser, createInput)).rejects.toMatchObject({
+        code: 'DUPLICATE_REPORT',
+      })
+    })
+
+    it('P2002以外のPrismaエラーはそのまま再スローされる', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+      const p2025 = new Prisma.PrismaClientKnownRequestError('Record not found', {
+        code: 'P2025',
+        clientVersion: '5.0.0',
+      })
+      mockCreate.mockRejectedValueOnce(p2025)
+
+      await expect(createReport(salesUser, createInput)).rejects.toBeInstanceOf(
+        Prisma.PrismaClientKnownRequestError,
+      )
     })
   })
 })

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listReports } from './reports.service'
+import { listReports, createReport } from './reports.service'
 import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
 
 vi.mock('@/lib/prisma', () => ({
@@ -8,12 +9,17 @@ vi.mock('@/lib/prisma', () => ({
     dailyReport: {
       count: vi.fn(),
       findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
     },
+    $transaction: vi.fn(),
   },
 }))
 
 const mockCount = vi.mocked(prisma.dailyReport.count)
 const mockFindMany = vi.mocked(prisma.dailyReport.findMany)
+const mockFindUnique = vi.mocked(prisma.dailyReport.findUnique)
+const mockTransaction = vi.mocked(prisma.$transaction)
 
 // ─── Test users ───────────────────────────────────────────────────────────────
 
@@ -328,6 +334,150 @@ describe('listReports', () => {
       expect(mockFindMany).toHaveBeenCalledWith(
         expect.objectContaining({ orderBy: { reportDate: 'desc' } }),
       )
+    })
+  })
+})
+
+// ─── createReport ─────────────────────────────────────────────────────────────
+
+const createInput = {
+  report_date: '2026-04-18',
+  problem: '課題テキスト',
+  plan: '明日やること',
+  visit_records: [
+    {
+      customer_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      content: '商談内容',
+      sort_order: 1,
+    },
+  ],
+}
+
+function makePrismaCreatedReport() {
+  return {
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    userId: salesUser.id,
+    reportDate: new Date('2026-04-18'),
+    problem: '課題テキスト',
+    plan: '明日やること',
+    createdAt: new Date('2026-04-18T09:00:00.000Z'),
+    updatedAt: new Date('2026-04-18T09:00:00.000Z'),
+    user: { id: salesUser.id, name: salesUser.name },
+    visitRecords: [
+      {
+        id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        content: '商談内容',
+        sortOrder: 1,
+        customer: {
+          id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          name: '佐藤 健',
+          company: '株式会社A',
+        },
+      },
+    ],
+    _count: { comments: 0 },
+  }
+}
+
+describe('createReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  describe('正常系', () => {
+    it('重複がない場合は$transactionでDailyReportとVisitRecordsを作成し結果を返す', async () => {
+      const prismaReport = makePrismaCreatedReport()
+      mockFindUnique.mockResolvedValueOnce(null)
+      // $transaction calls the callback with a tx object — simulate by calling cb with prisma itself
+      mockTransaction.mockImplementationOnce(async (cb: (tx: typeof prisma) => Promise<unknown>) => {
+        return cb(prisma)
+      })
+      vi.mocked(prisma.dailyReport.create).mockResolvedValueOnce(prismaReport as never)
+
+      const result = await createReport(salesUser, createInput)
+
+      expect(result.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+      expect(result.report_date).toBe('2026-04-18')
+      expect(result.problem).toBe('課題テキスト')
+      expect(result.plan).toBe('明日やること')
+      expect(result.user.id).toBe(salesUser.id)
+      expect(result.visit_records).toHaveLength(1)
+      expect(result.comments_count).toBe(0)
+    })
+
+    it('findUniqueはuserId + reportDateの複合ユニークキーで呼ばれる', async () => {
+      const prismaReport = makePrismaCreatedReport()
+      mockFindUnique.mockResolvedValueOnce(null)
+      mockTransaction.mockImplementationOnce(async (cb: (tx: typeof prisma) => Promise<unknown>) => {
+        return cb(prisma)
+      })
+      vi.mocked(prisma.dailyReport.create).mockResolvedValueOnce(prismaReport as never)
+
+      await createReport(salesUser, createInput)
+
+      expect(mockFindUnique).toHaveBeenCalledWith({
+        where: {
+          userId_reportDate: {
+            userId: salesUser.id,
+            reportDate: new Date('2026-04-18'),
+          },
+        },
+      })
+    })
+
+    it('レスポンスのvisit_recordsにcustomer情報・content・sort_orderが含まれる', async () => {
+      const prismaReport = makePrismaCreatedReport()
+      mockFindUnique.mockResolvedValueOnce(null)
+      mockTransaction.mockImplementationOnce(async (cb: (tx: typeof prisma) => Promise<unknown>) => {
+        return cb(prisma)
+      })
+      vi.mocked(prisma.dailyReport.create).mockResolvedValueOnce(prismaReport as never)
+
+      const result = await createReport(salesUser, createInput)
+
+      const vr = result.visit_records[0]
+      expect(vr.id).toBe('dddddddd-dddd-dddd-dddd-dddddddddddd')
+      expect(vr.customer.id).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc')
+      expect(vr.customer.name).toBe('佐藤 健')
+      expect(vr.customer.company).toBe('株式会社A')
+      expect(vr.content).toBe('商談内容')
+      expect(vr.sort_order).toBe(1)
+    })
+
+    it('created_atとupdated_atがISO 8601文字列に変換される', async () => {
+      const prismaReport = makePrismaCreatedReport()
+      mockFindUnique.mockResolvedValueOnce(null)
+      mockTransaction.mockImplementationOnce(async (cb: (tx: typeof prisma) => Promise<unknown>) => {
+        return cb(prisma)
+      })
+      vi.mocked(prisma.dailyReport.create).mockResolvedValueOnce(prismaReport as never)
+
+      const result = await createReport(salesUser, createInput)
+
+      expect(result.created_at).toBe('2026-04-18T09:00:00.000Z')
+      expect(result.updated_at).toBe('2026-04-18T09:00:00.000Z')
+    })
+  })
+
+  // ── Duplicate check ───────────────────────────────────────────────────────
+
+  describe('重複チェック', () => {
+    it('同じuserId + reportDateの日報が既に存在する場合はAPPError DUPLICATE_REPORTをスローする', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaCreatedReport() as never)
+
+      await expect(createReport(salesUser, createInput)).rejects.toMatchObject({
+        code: 'DUPLICATE_REPORT',
+      })
+    })
+
+    it('重複時は$transactionが呼ばれない', async () => {
+      mockFindUnique.mockResolvedValueOnce(makePrismaCreatedReport() as never)
+
+      await expect(createReport(salesUser, createInput)).rejects.toBeInstanceOf(AppError)
+
+      expect(mockTransaction).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
@@ -27,8 +28,8 @@ export interface ReportListItem {
   updated_at: string
 }
 
-// ReportDetail is the same shape as ReportListItem — reused for single-resource responses
-export type ReportDetail = ReportListItem
+// POST /reports レスポンス型（ReportListItemと同形。GET /reports/:idのReportDetailとは別定義）
+export type CreateReportResult = ReportListItem
 
 export interface ListReportsResult {
   data: ReportListItem[]
@@ -131,10 +132,10 @@ export async function listReports(
 export async function createReport(
   user: AuthUser,
   input: CreateReportInput,
-): Promise<ReportDetail> {
+): Promise<CreateReportResult> {
   const reportDate = new Date(input.report_date)
 
-  // Check for duplicate: same user + same date
+  // Early duplicate check: same user + same date (common path)
   const existing = await prisma.dailyReport.findUnique({
     where: {
       userId_reportDate: {
@@ -147,9 +148,10 @@ export async function createReport(
     throw AppError.duplicateReport()
   }
 
-  // Create report and all visit_records atomically
-  const report = await prisma.$transaction(async (tx) => {
-    const created = await tx.dailyReport.create({
+  // Nested create is atomic — no explicit transaction needed
+  let report
+  try {
+    report = await prisma.dailyReport.create({
       data: {
         userId: user.id,
         reportDate,
@@ -180,8 +182,13 @@ export async function createReport(
         },
       },
     })
-    return created
-  })
+  } catch (err) {
+    // Race condition: another request inserted the same user+date between our check and insert
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      throw AppError.duplicateReport()
+    }
+    throw err
+  }
 
   return {
     id: report.id,

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
-import type { ListReportsQuery } from '@/lib/schemas/report.schema'
+import type { ListReportsQuery, CreateReportInput } from '@/lib/schemas/report.schema'
 
 export interface ReportListItem {
   id: string
@@ -25,6 +26,9 @@ export interface ReportListItem {
   created_at: string
   updated_at: string
 }
+
+// ReportDetail is the same shape as ReportListItem — reused for single-resource responses
+export type ReportDetail = ReportListItem
 
 export interface ListReportsResult {
   data: ReportListItem[]
@@ -121,5 +125,85 @@ export async function listReports(
   return {
     data,
     meta: { total, page, per_page },
+  }
+}
+
+export async function createReport(
+  user: AuthUser,
+  input: CreateReportInput,
+): Promise<ReportDetail> {
+  const reportDate = new Date(input.report_date)
+
+  // Check for duplicate: same user + same date
+  const existing = await prisma.dailyReport.findUnique({
+    where: {
+      userId_reportDate: {
+        userId: user.id,
+        reportDate,
+      },
+    },
+  })
+  if (existing) {
+    throw AppError.duplicateReport()
+  }
+
+  // Create report and all visit_records atomically
+  const report = await prisma.$transaction(async (tx) => {
+    const created = await tx.dailyReport.create({
+      data: {
+        userId: user.id,
+        reportDate,
+        problem: input.problem,
+        plan: input.plan,
+        visitRecords: {
+          create: input.visit_records.map((vr) => ({
+            customerId: vr.customer_id,
+            content: vr.content,
+            sortOrder: vr.sort_order,
+          })),
+        },
+      },
+      include: {
+        user: {
+          select: { id: true, name: true },
+        },
+        visitRecords: {
+          orderBy: { sortOrder: 'asc' },
+          include: {
+            customer: {
+              select: { id: true, name: true, company: true },
+            },
+          },
+        },
+        _count: {
+          select: { comments: true },
+        },
+      },
+    })
+    return created
+  })
+
+  return {
+    id: report.id,
+    report_date: report.reportDate.toISOString().slice(0, 10),
+    problem: report.problem,
+    plan: report.plan,
+    user: {
+      id: report.user.id,
+      name: report.user.name,
+    },
+    visit_records: report.visitRecords.map((vr) => ({
+      id: vr.id,
+      customer: {
+        id: vr.customer.id,
+        name: vr.customer.name,
+        company: vr.customer.company,
+      },
+      content: vr.content,
+      sort_order: vr.sortOrder,
+    })),
+    comments_count: report._count.comments,
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
   }
 }


### PR DESCRIPTION
## Summary
- `POST /reports` エンドポイント実装（`sales` ロール限定）
- Prismaトランザクションによる日報・訪問記録の一括INSERT
- 同日重複チェック（409 DUPLICATE_REPORT）
- `withAuth(handler, ['sales'])` によるロールガード（manager/admin → 403）

## Changes
- `src/app/api/reports/route.ts` — POST ハンドラ追加
- `src/lib/reports/reports.service.ts` — `createReport` 関数追加
- `src/app/api/reports/route.test.ts` — POST テスト 13件追加
- `src/lib/reports/reports.service.test.ts` — `createReport` テスト 6件追加

## Test plan
- [ ] POST /reports (sales) → 201 + created report body
- [ ] POST /reports (manager) → 403 FORBIDDEN
- [ ] POST /reports (admin) → 403 FORBIDDEN
- [ ] POST /reports (no auth) → 401 UNAUTHORIZED
- [ ] POST /reports (empty visit_records) → 400 VALIDATION_ERROR
- [ ] POST /reports (duplicate date) → 409 DUPLICATE_REPORT
- [ ] 全251テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)