### PR TITLE
feat: PUT /reports/:id - 日報更新API実装 (closes #10)

### DIFF
--- a/src/app/api/reports/[id]/route.test.ts
+++ b/src/app/api/reports/[id]/route.test.ts
@@ -150,6 +150,17 @@ function makePutRequestWithoutAuth(reportId = REPORT_ID): NextRequest {
   })
 }
 
+function makePutRequestWithInvalidJson(user: AuthUser, reportId = REPORT_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+      'Content-Type': 'application/json',
+    },
+    body: 'not-valid-json{',
+  })
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('GET /api/reports/:id', () => {
@@ -529,6 +540,16 @@ describe('PUT /api/reports/:id', () => {
     it('problemが欠けている場合は400とVALIDATION_ERRORを返す', async () => {
       const { problem: _omit, ...bodyWithoutProblem } = validUpdateBody
       const req = makePutRequest(salesUser, bodyWithoutProblem)
+      const res = await PUT(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      expect(mockUpdateReport).not.toHaveBeenCalled()
+    })
+
+    it('不正なJSONボディの場合は400とVALIDATION_ERRORを返す', async () => {
+      const req = makePutRequestWithInvalidJson(salesUser)
       const res = await PUT(req, makeContext())
       const body = await res.json()
 

--- a/src/app/api/reports/[id]/route.test.ts
+++ b/src/app/api/reports/[id]/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
-import { GET } from './route'
+import { GET, PUT } from './route'
 import * as reportsService from '@/lib/reports/reports.service'
 import { generateToken } from '@/lib/auth/jwt'
 import { AppError } from '@/lib/errors/AppError'
@@ -10,6 +10,7 @@ import type { ReportDetail } from '@/lib/reports/reports.service'
 vi.mock('@/lib/reports/reports.service', () => ({
   listReports: vi.fn(),
   getReport: vi.fn(),
+  updateReport: vi.fn(),
 }))
 
 // Mock the blacklist so tokens are never invalidated in tests
@@ -18,6 +19,7 @@ vi.mock('@/lib/auth/blacklist', () => ({
 }))
 
 const mockGetReport = vi.mocked(reportsService.getReport)
+const mockUpdateReport = vi.mocked(reportsService.updateReport)
 
 // ─── Test users ───────────────────────────────────────────────────────────────
 
@@ -109,6 +111,43 @@ function makeRequestWithoutAuth(reportId = REPORT_ID): NextRequest {
 
 function makeContext(reportId = REPORT_ID): Record<string, unknown> {
   return { params: { id: reportId } }
+}
+
+// ─── PUT helpers ──────────────────────────────────────────────────────────────
+
+const validUpdateBody = {
+  problem: '更新後課題',
+  plan: '更新後予定',
+  visit_records: [
+    {
+      customer_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      content: '更新後訪問内容',
+      sort_order: 1,
+    },
+  ],
+}
+
+function makePutRequest(
+  user: AuthUser,
+  body: unknown = validUpdateBody,
+  reportId = REPORT_ID,
+): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function makePutRequestWithoutAuth(reportId = REPORT_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(validUpdateBody),
+  })
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -366,6 +405,147 @@ describe('GET /api/reports/:id', () => {
 
       const req = makeRequest(salesUser)
       const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})
+
+// ─── PUT /api/reports/:id ──────────────────────────────────────────────────────
+
+describe('PUT /api/reports/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── 認証 ──────────────────────────────────────────────────────────────────
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = makePutRequestWithoutAuth()
+      const res = await PUT(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+      expect(mockUpdateReport).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── API-019: 作成者が更新 → 200 ────────────────────────────────────────
+
+  describe('API-019: 作成者が自分の日報を更新すると200と更新後の日報を返す', () => {
+    it('200と更新後のReportDetailを返す', async () => {
+      const updatedReport: ReportDetail = {
+        ...sampleReportDetail,
+        problem: '更新後課題',
+        plan: '更新後予定',
+        visit_records: [
+          {
+            id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+            customer: {
+              id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+              name: '佐藤 健',
+              company: '株式会社A',
+            },
+            content: '更新後訪問内容',
+            sort_order: 1,
+          },
+        ],
+      }
+      mockUpdateReport.mockResolvedValueOnce(updatedReport)
+
+      const req = makePutRequest(salesUser)
+      const res = await PUT(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data.problem).toBe('更新後課題')
+      expect(body.data.plan).toBe('更新後予定')
+      expect(body.data.visit_records[0].content).toBe('更新後訪問内容')
+      expect(mockUpdateReport).toHaveBeenCalledWith(salesUser, REPORT_ID, validUpdateBody)
+    })
+  })
+
+  // ── API-020: 作成者以外が更新 → 403 FORBIDDEN ────────────────────────────
+
+  describe('API-020: 作成者以外のsalesユーザーが更新しようとすると403を返す', () => {
+    it('403とFORBIDDENコードを返す', async () => {
+      mockUpdateReport.mockRejectedValueOnce(AppError.forbidden())
+
+      const req = makePutRequest(salesUser2)
+      const res = await PUT(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ── UUID形式でないIDを指定 → 404 ─────────────────────────────────────────
+
+  describe('UUID形式でないIDを指定すると404を返す', () => {
+    it('404とNOT_FOUNDコードを返し、サービスは呼ばれない', async () => {
+      const req = makePutRequest(salesUser, validUpdateBody, 'not-a-uuid')
+      const res = await PUT(req, makeContext('not-a-uuid'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockUpdateReport).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── 存在しない日報ID → 404 ────────────────────────────────────────────────
+
+  describe('存在しない日報IDを指定すると404を返す', () => {
+    it('サービスがNOT_FOUNDをスローした場合に404を返す', async () => {
+      mockUpdateReport.mockRejectedValueOnce(AppError.notFound('日報'))
+
+      const req = makePutRequest(salesUser, validUpdateBody, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
+      const res = await PUT(req, makeContext('ffffffff-ffff-ffff-ffff-ffffffffffff'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+  })
+
+  // ── バリデーションエラー → 400 ───────────────────────────────────────────
+
+  describe('バリデーションエラー', () => {
+    it('visit_recordsが空配列の場合は400とVALIDATION_ERRORを返す', async () => {
+      const req = makePutRequest(salesUser, { ...validUpdateBody, visit_records: [] })
+      const res = await PUT(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      expect(mockUpdateReport).not.toHaveBeenCalled()
+    })
+
+    it('problemが欠けている場合は400とVALIDATION_ERRORを返す', async () => {
+      const { problem: _omit, ...bodyWithoutProblem } = validUpdateBody
+      const req = makePutRequest(salesUser, bodyWithoutProblem)
+      const res = await PUT(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      expect(mockUpdateReport).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── 予期しないエラー → 500 ───────────────────────────────────────────────
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockUpdateReport.mockRejectedValueOnce(new Error('Database connection failed'))
+
+      const req = makePutRequest(salesUser)
+      const res = await PUT(req, makeContext())
       const body = await res.json()
 
       expect(res.status).toBe(500)

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth } from '@/lib/auth/guard'
-import { getReport } from '@/lib/reports/reports.service'
-import { handleError } from '@/lib/errors'
+import { getReport, updateReport } from '@/lib/reports/reports.service'
+import { handleError, formatZodError } from '@/lib/errors'
 import { AppError } from '@/lib/errors/AppError'
+import { updateReportSchema } from '@/lib/schemas/report.schema'
 import type { AuthUser } from '@/types'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -28,3 +29,31 @@ async function handleGetReport(
 }
 
 export const GET = withAuth(handleGetReport)
+
+async function handlePutReport(
+  req: NextRequest,
+  context: Record<string, unknown>,
+  user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const params = await (context.params as Promise<{ id: string }>)
+    const reportId = params.id
+
+    if (!UUID_REGEX.test(reportId)) {
+      throw AppError.notFound('日報')
+    }
+
+    const body: unknown = await req.json()
+    const parsed = updateReportSchema.safeParse(body)
+    if (!parsed.success) {
+      throw formatZodError(parsed.error)
+    }
+
+    const data = await updateReport(user, reportId, parsed.data)
+    return NextResponse.json({ data })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const PUT = withAuth(handlePutReport)

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth } from '@/lib/auth/guard'
 import { getReport, updateReport } from '@/lib/reports/reports.service'
-import { handleError, formatZodError } from '@/lib/errors'
+import { handleError } from '@/lib/errors'
 import { AppError } from '@/lib/errors/AppError'
 import { updateReportSchema } from '@/lib/schemas/report.schema'
 import type { AuthUser } from '@/types'
@@ -43,13 +43,15 @@ async function handlePutReport(
       throw AppError.notFound('日報')
     }
 
-    const body: unknown = await req.json()
-    const parsed = updateReportSchema.safeParse(body)
-    if (!parsed.success) {
-      throw formatZodError(parsed.error)
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      throw AppError.validationError('リクエストボディが不正なJSON形式です')
     }
 
-    const data = await updateReport(user, reportId, parsed.data)
+    const input = updateReportSchema.parse(body)
+    const data = await updateReport(user, reportId, input)
     return NextResponse.json({ data })
   } catch (err) {
     return handleError(err)

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listReports, getReport, createReport } from './reports.service'
+import { listReports, getReport, createReport, updateReport } from './reports.service'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
 import { Prisma } from '@prisma/client'
@@ -7,11 +7,16 @@ import type { AuthUser } from '@/types'
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
+    $transaction: vi.fn(),
     dailyReport: {
       count: vi.fn(),
       findMany: vi.fn(),
       findUnique: vi.fn(),
       create: vi.fn(),
+      update: vi.fn(),
+    },
+    visitRecord: {
+      deleteMany: vi.fn(),
     },
   },
 }))
@@ -20,6 +25,9 @@ const mockCount = vi.mocked(prisma.dailyReport.count)
 const mockFindMany = vi.mocked(prisma.dailyReport.findMany)
 const mockFindUnique = vi.mocked(prisma.dailyReport.findUnique)
 const mockCreate = vi.mocked(prisma.dailyReport.create)
+const mockUpdate = vi.mocked(prisma.dailyReport.update)
+const mockDeleteMany = vi.mocked(prisma.visitRecord.deleteMany)
+const mockTransaction = vi.mocked(prisma.$transaction)
 
 // ─── Test users ───────────────────────────────────────────────────────────────
 
@@ -712,6 +720,145 @@ describe('getReport', () => {
           }),
         }),
       )
+    })
+  })
+})
+
+// ─── updateReport ─────────────────────────────────────────────────────────────
+
+const updateInput = {
+  problem: '更新後課題',
+  plan: '更新後予定',
+  visit_records: [
+    {
+      customer_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      content: '更新後訪問内容',
+      sort_order: 1,
+    },
+  ],
+}
+
+function makePrismaUpdatedReport() {
+  return {
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    userId: salesUser.id,
+    reportDate: new Date('2026-04-19'),
+    problem: '更新後課題',
+    plan: '更新後予定',
+    createdAt: new Date('2026-04-19T09:00:00.000Z'),
+    updatedAt: new Date('2026-04-19T12:00:00.000Z'),
+    user: { id: salesUser.id, name: salesUser.name, role: 'sales' as const },
+    visitRecords: [
+      {
+        id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+        content: '更新後訪問内容',
+        sortOrder: 1,
+        customer: {
+          id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          name: '佐藤 健',
+          company: '株式会社A',
+        },
+      },
+    ],
+    comments: [],
+  }
+}
+
+describe('updateReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  describe('正常系', () => {
+    it('作成者が更新するとトランザクション内でdeleteMany+updateが実行されReportDetailを返す', async () => {
+      mockFindUnique.mockResolvedValueOnce({ userId: salesUser.id } as never)
+      mockTransaction.mockImplementation(async (fn) => fn(prisma))
+      mockDeleteMany.mockResolvedValueOnce({ count: 1 })
+      mockUpdate.mockResolvedValueOnce(makePrismaUpdatedReport() as never)
+
+      const result = await updateReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', updateInput)
+
+      expect(mockTransaction).toHaveBeenCalledOnce()
+      expect(mockDeleteMany).toHaveBeenCalledWith({
+        where: { dailyReportId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' },
+      })
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' },
+          data: expect.objectContaining({
+            problem: '更新後課題',
+            plan: '更新後予定',
+          }),
+        }),
+      )
+      expect(result.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+      expect(result.problem).toBe('更新後課題')
+      expect(result.plan).toBe('更新後予定')
+      expect(result.visit_records).toHaveLength(1)
+      expect(result.visit_records[0].content).toBe('更新後訪問内容')
+    })
+
+    it('レスポンスにuser.roleが含まれる', async () => {
+      mockFindUnique.mockResolvedValueOnce({ userId: salesUser.id } as never)
+      mockTransaction.mockImplementation(async (fn) => fn(prisma))
+      mockDeleteMany.mockResolvedValueOnce({ count: 1 })
+      mockUpdate.mockResolvedValueOnce(makePrismaUpdatedReport() as never)
+
+      const result = await updateReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', updateInput)
+
+      expect(result.user.role).toBe('sales')
+    })
+
+    it('updated_atがISO 8601文字列に変換される', async () => {
+      mockFindUnique.mockResolvedValueOnce({ userId: salesUser.id } as never)
+      mockTransaction.mockImplementation(async (fn) => fn(prisma))
+      mockDeleteMany.mockResolvedValueOnce({ count: 1 })
+      mockUpdate.mockResolvedValueOnce(makePrismaUpdatedReport() as never)
+
+      const result = await updateReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', updateInput)
+
+      expect(result.updated_at).toBe('2026-04-19T12:00:00.000Z')
+    })
+  })
+
+  // ── Not found ─────────────────────────────────────────────────────────────
+
+  describe('存在しないID', () => {
+    it('findUniqueがnullを返す場合はNOT_FOUNDをスローする', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+
+      await expect(
+        updateReport(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff', updateInput),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── Forbidden ─────────────────────────────────────────────────────────────
+
+  describe('権限チェック', () => {
+    it('作成者以外がリクエストするとFORBIDDENをスローする', async () => {
+      // Report belongs to salesUser2, but salesUser is the requester
+      mockFindUnique.mockResolvedValueOnce({ userId: salesUser2.id } as never)
+
+      await expect(
+        updateReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', updateInput),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+    })
+
+    it('managerロールが他人の日報を更新しようとするとFORBIDDENをスローする', async () => {
+      mockFindUnique.mockResolvedValueOnce({ userId: salesUser.id } as never)
+
+      await expect(
+        updateReport(managerUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', updateInput),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+
+      expect(mockTransaction).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -861,4 +861,38 @@ describe('updateReport', () => {
       expect(mockTransaction).not.toHaveBeenCalled()
     })
   })
+
+  // ── Race condition ────────────────────────────────────────────────────────
+
+  describe('レースコンディション', () => {
+    it('トランザクション内でP2025が発生した場合はNOT_FOUNDをスローする', async () => {
+      mockFindUnique.mockResolvedValueOnce({ userId: salesUser.id } as never)
+      mockTransaction.mockImplementation(async (fn) => fn(prisma))
+      mockDeleteMany.mockResolvedValueOnce({ count: 0 })
+      const p2025 = new Prisma.PrismaClientKnownRequestError('Record to update not found', {
+        code: 'P2025',
+        clientVersion: '5.0.0',
+      })
+      mockUpdate.mockRejectedValueOnce(p2025)
+
+      await expect(
+        updateReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', updateInput),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    })
+
+    it('P2025以外のPrismaエラーはそのまま再スローされる', async () => {
+      mockFindUnique.mockResolvedValueOnce({ userId: salesUser.id } as never)
+      mockTransaction.mockImplementation(async (fn) => fn(prisma))
+      mockDeleteMany.mockResolvedValueOnce({ count: 0 })
+      const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: '5.0.0',
+      })
+      mockUpdate.mockRejectedValueOnce(p2002)
+
+      await expect(
+        updateReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', updateInput),
+      ).rejects.toBeInstanceOf(Prisma.PrismaClientKnownRequestError)
+    })
+  })
 })

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -272,41 +272,41 @@ export async function updateReport(
       await tx.visitRecord.deleteMany({ where: { dailyReportId: reportId } })
 
       return tx.dailyReport.update({
-      where: { id: reportId },
-      data: {
-        problem: input.problem,
-        plan: input.plan,
-        visitRecords: {
-          create: input.visit_records.map((vr) => ({
-            customerId: vr.customer_id,
-            content: vr.content,
-            sortOrder: vr.sort_order,
-          })),
+        where: { id: reportId },
+        data: {
+          problem: input.problem,
+          plan: input.plan,
+          visitRecords: {
+            create: input.visit_records.map((vr) => ({
+              customerId: vr.customer_id,
+              content: vr.content,
+              sortOrder: vr.sort_order,
+            })),
+          },
         },
-      },
-      include: {
-        user: {
-          select: { id: true, name: true, role: true },
-        },
-        visitRecords: {
-          orderBy: { sortOrder: 'asc' },
-          include: {
-            customer: {
-              select: { id: true, name: true, company: true },
+        include: {
+          user: {
+            select: { id: true, name: true, role: true },
+          },
+          visitRecords: {
+            orderBy: { sortOrder: 'asc' },
+            include: {
+              customer: {
+                select: { id: true, name: true, company: true },
+              },
+            },
+          },
+          comments: {
+            orderBy: { createdAt: 'asc' },
+            include: {
+              commenter: {
+                select: { id: true, name: true },
+              },
             },
           },
         },
-        comments: {
-          orderBy: { createdAt: 'asc' },
-          include: {
-            commenter: {
-              select: { id: true, name: true },
-            },
-          },
-        },
-      },
+      })
     })
-  })
   } catch (err) {
     // Race condition: report was deleted between the ownership check and the update
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser, UserRole } from '@/types'
-import type { ListReportsQuery, CreateReportInput } from '@/lib/schemas/report.schema'
+import type { ListReportsQuery, CreateReportInput, UpdateReportInput } from '@/lib/schemas/report.schema'
 
 export interface ReportListItem {
   id: string
@@ -243,6 +243,98 @@ export async function createReport(
       sort_order: vr.sortOrder,
     })),
     comments_count: report._count.comments,
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  }
+}
+
+export async function updateReport(
+  user: AuthUser,
+  reportId: string,
+  input: UpdateReportInput,
+): Promise<ReportDetail> {
+  const existing = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    select: { userId: true },
+  })
+
+  if (!existing) {
+    throw AppError.notFound('日報')
+  }
+
+  if (existing.userId !== user.id) {
+    throw AppError.forbidden()
+  }
+
+  const report = await prisma.$transaction(async (tx) => {
+    await tx.visitRecord.deleteMany({ where: { dailyReportId: reportId } })
+
+    return tx.dailyReport.update({
+      where: { id: reportId },
+      data: {
+        problem: input.problem,
+        plan: input.plan,
+        visitRecords: {
+          create: input.visit_records.map((vr) => ({
+            customerId: vr.customer_id,
+            content: vr.content,
+            sortOrder: vr.sort_order,
+          })),
+        },
+      },
+      include: {
+        user: {
+          select: { id: true, name: true, role: true },
+        },
+        visitRecords: {
+          orderBy: { sortOrder: 'asc' },
+          include: {
+            customer: {
+              select: { id: true, name: true, company: true },
+            },
+          },
+        },
+        comments: {
+          orderBy: { createdAt: 'asc' },
+          include: {
+            commenter: {
+              select: { id: true, name: true },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  return {
+    id: report.id,
+    report_date: report.reportDate.toISOString().slice(0, 10),
+    problem: report.problem,
+    plan: report.plan,
+    user: {
+      id: report.user.id,
+      name: report.user.name,
+      role: report.user.role,
+    },
+    visit_records: report.visitRecords.map((vr) => ({
+      id: vr.id,
+      customer: {
+        id: vr.customer.id,
+        name: vr.customer.name,
+        company: vr.customer.company,
+      },
+      content: vr.content,
+      sort_order: vr.sortOrder,
+    })),
+    comments: report.comments.map((c) => ({
+      id: c.id,
+      body: c.body,
+      commenter: {
+        id: c.commenter.id,
+        name: c.commenter.name,
+      },
+      created_at: c.createdAt.toISOString(),
+    })),
     created_at: report.createdAt.toISOString(),
     updated_at: report.updatedAt.toISOString(),
   }

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -266,10 +266,12 @@ export async function updateReport(
     throw AppError.forbidden()
   }
 
-  const report = await prisma.$transaction(async (tx) => {
-    await tx.visitRecord.deleteMany({ where: { dailyReportId: reportId } })
+  let report
+  try {
+    report = await prisma.$transaction(async (tx) => {
+      await tx.visitRecord.deleteMany({ where: { dailyReportId: reportId } })
 
-    return tx.dailyReport.update({
+      return tx.dailyReport.update({
       where: { id: reportId },
       data: {
         problem: input.problem,
@@ -305,6 +307,13 @@ export async function updateReport(
       },
     })
   })
+  } catch (err) {
+    // Race condition: report was deleted between the ownership check and the update
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw AppError.notFound('日報')
+    }
+    throw err
+  }
 
   return {
     id: report.id,


### PR DESCRIPTION
## Summary
- `PUT /reports/:id` エンドポイント実装（認証必要・日報作成者本人のみ）
- `visit_records` の全件洗い替え（`deleteMany` → `update` をトランザクション内で実行）
- UUID形式の ID 事前バリデーション（非UUID → 404）
- 本人チェック（`report.userId !== user.id` → 403）、存在チェック（→ 404）
- `report_date` は変更不可（`updateReportSchema` で除外済み）

## Changes
- `src/app/api/reports/[id]/route.ts` — PUT ハンドラ追加
- `src/lib/reports/reports.service.ts` — `updateReport` 関数追加
- `src/app/api/reports/[id]/route.test.ts` — PUT テスト追加
- `src/lib/reports/reports.service.test.ts` — `updateReport` テスト追加

## Test plan
- [ ] PUT /reports/:id (author) → 200 + updated report body (API-019)
- [ ] PUT /reports/:id (non-author) → 403 FORBIDDEN (API-020)
- [ ] PUT /reports/:id (no auth) → 401 UNAUTHORIZED
- [ ] PUT /reports/not-a-uuid → 404 NOT_FOUND
- [ ] PUT /reports/:id (not found) → 404 NOT_FOUND
- [ ] PUT /reports/:id (empty visit_records) → 400 VALIDATION_ERROR
- [ ] 全294テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)