### PR TITLE
feat: DELETE /reports/:id 日報削除API実装 (closes #11)

### DIFF
--- a/src/app/api/reports/[id]/route.test.ts
+++ b/src/app/api/reports/[id]/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
-import { GET } from './route'
+import { GET, DELETE } from './route'
 import * as reportsService from '@/lib/reports/reports.service'
 import { generateToken } from '@/lib/auth/jwt'
 import { AppError } from '@/lib/errors/AppError'
@@ -10,6 +10,7 @@ import type { ReportDetail } from '@/lib/reports/reports.service'
 vi.mock('@/lib/reports/reports.service', () => ({
   listReports: vi.fn(),
   getReport: vi.fn(),
+  deleteReport: vi.fn(),
 }))
 
 // Mock the blacklist so tokens are never invalidated in tests
@@ -18,6 +19,7 @@ vi.mock('@/lib/auth/blacklist', () => ({
 }))
 
 const mockGetReport = vi.mocked(reportsService.getReport)
+const mockDeleteReport = vi.mocked(reportsService.deleteReport)
 
 // ─── Test users ───────────────────────────────────────────────────────────────
 
@@ -104,6 +106,21 @@ function makeRequest(user: AuthUser, reportId = REPORT_ID): NextRequest {
 function makeRequestWithoutAuth(reportId = REPORT_ID): NextRequest {
   return new NextRequest(`http://localhost/api/reports/${reportId}`, {
     method: 'GET',
+  })
+}
+
+function makeDeleteRequest(user: AuthUser, reportId = REPORT_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+    },
+  })
+}
+
+function makeDeleteRequestWithoutAuth(reportId = REPORT_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}`, {
+    method: 'DELETE',
   })
 }
 
@@ -366,6 +383,127 @@ describe('GET /api/reports/:id', () => {
 
       const req = makeRequest(salesUser)
       const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})
+
+// ─── DELETE /api/reports/:id ──────────────────────────────────────────────────
+
+describe('DELETE /api/reports/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── 認証 ─────────────────────────────────────────────────────────────────
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = makeDeleteRequestWithoutAuth()
+      const res = await DELETE(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  // ── API-021: 作成者本人トークン → 204 ────────────────────────────────────
+
+  describe('API-021: 作成者本人が削除すると204を返す', () => {
+    it('204 No Content でボディなしのレスポンスを返す', async () => {
+      mockDeleteReport.mockResolvedValueOnce(undefined)
+
+      const req = makeDeleteRequest(salesUser)
+      const res = await DELETE(req, makeContext())
+
+      expect(res.status).toBe(204)
+      expect(res.body).toBeNull()
+      expect(mockDeleteReport).toHaveBeenCalledWith(salesUser, REPORT_ID)
+    })
+  })
+
+  // ── API-022: 別salesユーザーのトークン → 403 FORBIDDEN ───────────────────
+
+  describe('API-022: 別salesユーザーが削除しようとすると403を返す', () => {
+    it('403とFORBIDDENコードを返す', async () => {
+      mockDeleteReport.mockRejectedValueOnce(AppError.forbidden())
+
+      const req = makeDeleteRequest(salesUser2)
+      const res = await DELETE(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ── managerのトークン → 403 FORBIDDEN ────────────────────────────────────
+
+  describe('managerが他人の日報を削除しようとすると403を返す', () => {
+    it('403とFORBIDDENコードを返す', async () => {
+      mockDeleteReport.mockRejectedValueOnce(AppError.forbidden())
+
+      const req = makeDeleteRequest(managerUser)
+      const res = await DELETE(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ── adminのトークン → 403 FORBIDDEN ──────────────────────────────────────
+
+  describe('adminが他人の日報を削除しようとすると403を返す', () => {
+    it('403とFORBIDDENコードを返す', async () => {
+      mockDeleteReport.mockRejectedValueOnce(AppError.forbidden())
+
+      const req = makeDeleteRequest(adminUser)
+      const res = await DELETE(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ── 存在しないID → 404 NOT_FOUND ─────────────────────────────────────────
+
+  describe('存在しないIDを指定すると404を返す', () => {
+    it('404とNOT_FOUNDコードを返す', async () => {
+      mockDeleteReport.mockRejectedValueOnce(AppError.notFound('日報'))
+
+      const req = makeDeleteRequest(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
+      const res = await DELETE(req, makeContext('ffffffff-ffff-ffff-ffff-ffffffffffff'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('UUID形式でないIDを指定すると404を返す（Prismaエラーを回避）', async () => {
+      const req = makeDeleteRequest(salesUser, 'not-a-uuid')
+      const res = await DELETE(req, makeContext('not-a-uuid'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockDeleteReport).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── エラーハンドリング ────────────────────────────────────────────────────
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockDeleteReport.mockRejectedValueOnce(new Error('Database connection failed'))
+
+      const req = makeDeleteRequest(salesUser)
+      const res = await DELETE(req, makeContext())
       const body = await res.json()
 
       expect(res.status).toBe(500)

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth } from '@/lib/auth/guard'
-import { getReport } from '@/lib/reports/reports.service'
+import { getReport, deleteReport } from '@/lib/reports/reports.service'
 import { handleError } from '@/lib/errors'
 import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
@@ -28,3 +28,25 @@ async function handleGetReport(
 }
 
 export const GET = withAuth(handleGetReport)
+
+async function handleDeleteReport(
+  _req: NextRequest,
+  context: Record<string, unknown>,
+  user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const params = await (context.params as Promise<{ id: string }>)
+    const reportId = params.id
+
+    if (!UUID_REGEX.test(reportId)) {
+      throw AppError.notFound('日報')
+    }
+
+    await deleteReport(user, reportId)
+    return new NextResponse(null, { status: 204 })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const DELETE = withAuth(handleDeleteReport)

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -825,10 +825,9 @@ describe('deleteReport', () => {
       expect(mockDelete).toHaveBeenCalledWith({ where: { id: reportId } })
     })
 
-    it('findUniqueはidとuserIdのみselectする', async () => {
+    it('findUniqueはuserIdのみselectする', async () => {
       const reportId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
       mockFindUnique.mockResolvedValueOnce({
-        id: reportId,
         userId: salesUser.id,
       } as never)
       mockDelete.mockResolvedValueOnce({} as never)
@@ -837,8 +836,44 @@ describe('deleteReport', () => {
 
       expect(mockFindUnique).toHaveBeenCalledWith({
         where: { id: reportId },
-        select: { id: true, userId: true },
+        select: { userId: true },
       })
+    })
+  })
+
+  // ── 競合状態（P2025）────────────────────────────────────────────────────
+
+  describe('競合状態', () => {
+    it('P2025（findUnique後に別リクエストが削除済み）の場合はNOT_FOUNDをスローする', async () => {
+      const reportId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+      mockFindUnique.mockResolvedValueOnce({
+        userId: salesUser.id,
+      } as never)
+      const p2025 = new Prisma.PrismaClientKnownRequestError('Record to delete does not exist.', {
+        code: 'P2025',
+        clientVersion: '5.0.0',
+      })
+      mockDelete.mockRejectedValueOnce(p2025)
+
+      await expect(deleteReport(salesUser, reportId)).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      })
+    })
+
+    it('P2025以外のPrismaエラーはそのまま再スローされる', async () => {
+      const reportId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+      mockFindUnique.mockResolvedValueOnce({
+        userId: salesUser.id,
+      } as never)
+      const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed.', {
+        code: 'P2002',
+        clientVersion: '5.0.0',
+      })
+      mockDelete.mockRejectedValueOnce(p2002)
+
+      await expect(deleteReport(salesUser, reportId)).rejects.toBeInstanceOf(
+        Prisma.PrismaClientKnownRequestError,
+      )
     })
   })
 })

--- a/src/lib/reports/reports.service.test.ts
+++ b/src/lib/reports/reports.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listReports, getReport, createReport } from './reports.service'
+import { listReports, getReport, createReport, deleteReport } from './reports.service'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
 import { Prisma } from '@prisma/client'
@@ -12,6 +12,7 @@ vi.mock('@/lib/prisma', () => ({
       findMany: vi.fn(),
       findUnique: vi.fn(),
       create: vi.fn(),
+      delete: vi.fn(),
     },
   },
 }))
@@ -20,6 +21,7 @@ const mockCount = vi.mocked(prisma.dailyReport.count)
 const mockFindMany = vi.mocked(prisma.dailyReport.findMany)
 const mockFindUnique = vi.mocked(prisma.dailyReport.findUnique)
 const mockCreate = vi.mocked(prisma.dailyReport.create)
+const mockDelete = vi.mocked(prisma.dailyReport.delete)
 
 // ─── Test users ───────────────────────────────────────────────────────────────
 
@@ -712,6 +714,131 @@ describe('getReport', () => {
           }),
         }),
       )
+    })
+  })
+})
+
+// ─── deleteReport tests ───────────────────────────────────────────────────────
+
+describe('deleteReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Not found ─────────────────────────────────────────────────────────────
+
+  describe('存在しないID', () => {
+    it('存在しないIDに対してAppError(NOT_FOUND)をスローする', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+
+      await expect(
+        deleteReport(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    })
+
+    it('NOT_FOUNDのとき deleteは呼ばれない', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+
+      await expect(
+        deleteReport(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+      ).rejects.toBeInstanceOf(AppError)
+
+      expect(mockDelete).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── 本人チェック ──────────────────────────────────────────────────────────
+
+  describe('本人チェック', () => {
+    it('他人の日報に対してAppError(FORBIDDEN)をスローする', async () => {
+      // Report belongs to salesUser2, but salesUser is the requester
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        userId: salesUser2.id,
+      } as never)
+
+      await expect(
+        deleteReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    })
+
+    it('FORBIDDENのとき deleteは呼ばれない', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        userId: salesUser2.id,
+      } as never)
+
+      await expect(
+        deleteReport(salesUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+      ).rejects.toBeInstanceOf(AppError)
+
+      expect(mockDelete).not.toHaveBeenCalled()
+    })
+
+    it('managerが他人の日報を削除しようとするとFORBIDDENをスローする', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        userId: salesUser.id,
+      } as never)
+
+      await expect(
+        deleteReport(managerUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    })
+
+    it('adminが他人の日報を削除しようとするとFORBIDDENをスローする', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        userId: salesUser.id,
+      } as never)
+
+      await expect(
+        deleteReport(adminUser, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    })
+  })
+
+  // ── 正常系 ────────────────────────────────────────────────────────────────
+
+  describe('正常系', () => {
+    it('本人の日報は正常に削除されvoidを返す', async () => {
+      const reportId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+      mockFindUnique.mockResolvedValueOnce({
+        id: reportId,
+        userId: salesUser.id,
+      } as never)
+      mockDelete.mockResolvedValueOnce({} as never)
+
+      await expect(deleteReport(salesUser, reportId)).resolves.toBeUndefined()
+    })
+
+    it('prisma.dailyReport.deleteが正しいIDで呼ばれる', async () => {
+      const reportId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+      mockFindUnique.mockResolvedValueOnce({
+        id: reportId,
+        userId: salesUser.id,
+      } as never)
+      mockDelete.mockResolvedValueOnce({} as never)
+
+      await deleteReport(salesUser, reportId)
+
+      expect(mockDelete).toHaveBeenCalledWith({ where: { id: reportId } })
+    })
+
+    it('findUniqueはidとuserIdのみselectする', async () => {
+      const reportId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+      mockFindUnique.mockResolvedValueOnce({
+        id: reportId,
+        userId: salesUser.id,
+      } as never)
+      mockDelete.mockResolvedValueOnce({} as never)
+
+      await deleteReport(salesUser, reportId)
+
+      expect(mockFindUnique).toHaveBeenCalledWith({
+        where: { id: reportId },
+        select: { id: true, userId: true },
+      })
     })
   })
 })

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -248,23 +248,6 @@ export async function createReport(
   }
 }
 
-export async function deleteReport(user: AuthUser, reportId: string): Promise<void> {
-  const report = await prisma.dailyReport.findUnique({
-    where: { id: reportId },
-    select: { id: true, userId: true },
-  })
-
-  if (!report) {
-    throw AppError.notFound('日報')
-  }
-
-  if (report.userId !== user.id) {
-    throw AppError.forbidden()
-  }
-
-  await prisma.dailyReport.delete({ where: { id: reportId } })
-}
-
 export async function getReport(user: AuthUser, reportId: string): Promise<ReportDetail> {
   const report = await prisma.dailyReport.findUnique({
     where: { id: reportId },
@@ -331,5 +314,30 @@ export async function getReport(user: AuthUser, reportId: string): Promise<Repor
     })),
     created_at: report.createdAt.toISOString(),
     updated_at: report.updatedAt.toISOString(),
+  }
+}
+
+export async function deleteReport(user: AuthUser, reportId: string): Promise<void> {
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    select: { userId: true },
+  })
+
+  if (!report) {
+    throw AppError.notFound('日報')
+  }
+
+  if (report.userId !== user.id) {
+    throw AppError.forbidden()
+  }
+
+  try {
+    await prisma.dailyReport.delete({ where: { id: reportId } })
+  } catch (err) {
+    // Race condition: another request deleted the same report between our check and delete
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw AppError.notFound('日報')
+    }
+    throw err
   }
 }

--- a/src/lib/reports/reports.service.ts
+++ b/src/lib/reports/reports.service.ts
@@ -248,6 +248,23 @@ export async function createReport(
   }
 }
 
+export async function deleteReport(user: AuthUser, reportId: string): Promise<void> {
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    select: { id: true, userId: true },
+  })
+
+  if (!report) {
+    throw AppError.notFound('日報')
+  }
+
+  if (report.userId !== user.id) {
+    throw AppError.forbidden()
+  }
+
+  await prisma.dailyReport.delete({ where: { id: reportId } })
+}
+
 export async function getReport(user: AuthUser, reportId: string): Promise<ReportDetail> {
   const report = await prisma.dailyReport.findUnique({
     where: { id: reportId },


### PR DESCRIPTION
## Summary

- `deleteReport` サービス関数を追加 — `findUnique` で対象日報を取得し、存在チェック・本人チェック後に `prisma.dailyReport.delete` を呼び出す
- `DELETE /api/reports/:id` ハンドラーを `route.ts` に追加 — UUID バリデーション後にサービスを呼び、成功時は `new NextResponse(null, { status: 204 })` を返す
- `onDelete: Cascade` により `VisitRecord` と `Comment` は自動削除される
- 認証ガードはロール制限なし（全ロール認証後に本人チェックをサービス層で実施）

## Test plan

### `src/app/api/reports/[id]/route.test.ts`
- [x] API-021: 作成者本人トークン → 204 No Content（ボディなし）
- [x] API-022: 別 sales ユーザーのトークン → 403 FORBIDDEN
- [x] manager のトークン → 403 FORBIDDEN（他人の日報のため）
- [x] admin のトークン → 403 FORBIDDEN（他人の日報のため）
- [x] 存在しない UUID → 404 NOT_FOUND
- [x] UUID 形式でない ID → 404 NOT_FOUND（Prisma エラー回避、`deleteReport` 未呼び出し）
- [x] 未認証（Authorization ヘッダーなし）→ 401 UNAUTHORIZED
- [x] サービスが予期しないエラーを投げた場合 → 500 INTERNAL_SERVER_ERROR

### `src/lib/reports/reports.service.test.ts`
- [x] 本人の日報 → 正常削除、`prisma.dailyReport.delete` が正しい ID で呼ばれる
- [x] `findUnique` が `{ id, userId }` のみ select することを確認
- [x] 存在しない ID → `NOT_FOUND`、`delete` 未呼び出し
- [x] 他 sales ユーザーの日報 → `FORBIDDEN`、`delete` 未呼び出し
- [x] manager が他人の日報 → `FORBIDDEN`
- [x] admin が他人の日報 → `FORBIDDEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)