### PR TITLE
feat: GET /reports/:id/comments コメント一覧API実装 (closes #13)

### DIFF
--- a/src/app/api/reports/[id]/comments/route.test.ts
+++ b/src/app/api/reports/[id]/comments/route.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+import * as commentsService from '@/lib/reports/comments.service'
+import { generateToken } from '@/lib/auth/jwt'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+import type { CommentItem } from '@/lib/reports/comments.service'
+
+vi.mock('@/lib/reports/comments.service', () => ({
+  listComments: vi.fn(),
+}))
+
+// Mock the blacklist so tokens are never invalidated in tests
+vi.mock('@/lib/auth/blacklist', () => ({
+  isBlacklisted: vi.fn().mockReturnValue(false),
+}))
+
+const mockListComments = vi.mocked(commentsService.listComments)
+
+// ─── Test users ───────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const salesUser2: AuthUser = {
+  id: '22222222-2222-2222-2222-222222222222',
+  name: '鈴木 一郎',
+  email: 'suzuki@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample data ──────────────────────────────────────────────────────────────
+
+const REPORT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+const sampleComments: CommentItem[] = [
+  {
+    id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    body: 'コメント本文',
+    commenter: {
+      id: managerUser.id,
+      name: managerUser.name,
+      role: 'manager',
+    },
+    created_at: '2026-04-19T18:32:00.000Z',
+    updated_at: '2026-04-19T18:32:00.000Z',
+  },
+]
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(user: AuthUser, reportId = REPORT_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}/comments`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+    },
+  })
+}
+
+function makeRequestWithoutAuth(reportId = REPORT_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${reportId}/comments`, {
+    method: 'GET',
+  })
+}
+
+function makeContext(reportId = REPORT_ID): Record<string, unknown> {
+  return { params: { id: reportId } }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/reports/:id/comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── 認証 ──────────────────────────────────────────────────────────────────
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = makeRequestWithoutAuth()
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+      expect(mockListComments).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── API-031: 任意のトークン → 200, コメント一覧 ──────────────────────────
+
+  describe('API-031: salesユーザーが自分の日報のコメント一覧を取得できる', () => {
+    it('200とdataにコメント一覧が含まれること', async () => {
+      mockListComments.mockResolvedValueOnce(sampleComments)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].id).toBe('dddddddd-dddd-dddd-dddd-dddddddddddd')
+      expect(body.data[0].body).toBe('コメント本文')
+      expect(mockListComments).toHaveBeenCalledWith(salesUser, REPORT_ID)
+    })
+
+    it('commenterにid・name・roleが含まれること', async () => {
+      mockListComments.mockResolvedValueOnce(sampleComments)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(body.data[0].commenter.id).toBe(managerUser.id)
+      expect(body.data[0].commenter.name).toBe(managerUser.name)
+      expect(body.data[0].commenter.role).toBe('manager')
+    })
+
+    it('created_atとupdated_atがISO 8601形式で含まれること', async () => {
+      mockListComments.mockResolvedValueOnce(sampleComments)
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(body.data[0].created_at).toBe('2026-04-19T18:32:00.000Z')
+      expect(body.data[0].updated_at).toBe('2026-04-19T18:32:00.000Z')
+    })
+  })
+
+  describe('API-031: managerが任意の日報のコメント一覧を取得できる', () => {
+    it('managerが200とコメント一覧を返す', async () => {
+      mockListComments.mockResolvedValueOnce(sampleComments)
+
+      const req = makeRequest(managerUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(1)
+      expect(mockListComments).toHaveBeenCalledWith(managerUser, REPORT_ID)
+    })
+  })
+
+  describe('API-031: adminが任意の日報のコメント一覧を取得できる', () => {
+    it('adminが200とコメント一覧を返す', async () => {
+      mockListComments.mockResolvedValueOnce(sampleComments)
+
+      const req = makeRequest(adminUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(1)
+      expect(mockListComments).toHaveBeenCalledWith(adminUser, REPORT_ID)
+    })
+  })
+
+  describe('コメントが0件の場合は空配列を返す', () => {
+    it('200と空のdataを返す', async () => {
+      mockListComments.mockResolvedValueOnce([])
+
+      const req = makeRequest(managerUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(0)
+      expect(Array.isArray(body.data)).toBe(true)
+    })
+  })
+
+  // ── NOT_FOUND ──────────────────────────────────────────────────────────────
+
+  describe('NOT_FOUND: 存在しない日報IDを指定すると404を返す', () => {
+    it('存在しない日報IDで404とNOT_FOUNDコードを返す', async () => {
+      mockListComments.mockRejectedValueOnce(AppError.notFound('日報'))
+
+      const req = makeRequest(salesUser, 'ffffffff-ffff-ffff-ffff-ffffffffffff')
+      const res = await GET(req, makeContext('ffffffff-ffff-ffff-ffff-ffffffffffff'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('UUID形式でないIDを指定すると404を返し、サービスは呼ばれない', async () => {
+      const req = makeRequest(salesUser, 'not-a-uuid')
+      const res = await GET(req, makeContext('not-a-uuid'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockListComments).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── FORBIDDEN: salesが他人の日報 → 403 ────────────────────────────────────
+
+  describe('FORBIDDEN: salesユーザーが他人の日報のコメントを取得しようとすると403を返す', () => {
+    it('他人の日報に対して403とFORBIDDENコードを返す', async () => {
+      mockListComments.mockRejectedValueOnce(AppError.forbidden())
+
+      const req = makeRequest(salesUser2)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ── エラーハンドリング ────────────────────────────────────────────────────
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockListComments.mockRejectedValueOnce(new Error('Database connection failed'))
+
+      const req = makeRequest(salesUser)
+      const res = await GET(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})

--- a/src/app/api/reports/[id]/comments/route.ts
+++ b/src/app/api/reports/[id]/comments/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/guard'
+import { listComments } from '@/lib/reports/comments.service'
+import { handleError } from '@/lib/errors'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+async function handleGetComments(
+  _req: NextRequest,
+  context: Record<string, unknown>,
+  user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const params = await (context.params as Promise<{ id: string }>)
+    const reportId = params.id
+
+    if (!UUID_REGEX.test(reportId)) {
+      throw AppError.notFound('日報')
+    }
+
+    const data = await listComments(user, reportId)
+    return NextResponse.json({ data })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const GET = withAuth(handleGetComments)

--- a/src/lib/reports/comments.service.test.ts
+++ b/src/lib/reports/comments.service.test.ts
@@ -183,16 +183,9 @@ describe('listComments', () => {
     it('日報が見つからない場合はAppError.notFoundをスローする', async () => {
       mockFindUniqueReport.mockResolvedValueOnce(null as never)
 
-      await expect(listComments(managerUser, REPORT_ID)).rejects.toThrow(AppError)
-
-      try {
-        await listComments(managerUser, REPORT_ID)
-      } catch (err) {
-        expect(err).toBeInstanceOf(AppError)
-        const appError = err as AppError
-        expect(appError.code).toBe('NOT_FOUND')
-        expect(appError.statusCode).toBe(404)
-      }
+      await expect(listComments(managerUser, REPORT_ID)).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      })
     })
 
     it('日報が見つからない場合はfindManyが呼ばれない', async () => {
@@ -209,22 +202,13 @@ describe('listComments', () => {
     it('他人の日報に対してAppError.forbiddenをスローする', async () => {
       // salesUser2が所有する日報（userId !== salesUser.id）
       const otherUsersReport = {
-        id: REPORT_ID,
         userId: salesUser2.id,
       }
       mockFindUniqueReport.mockResolvedValueOnce(otherUsersReport as never)
 
-      await expect(listComments(salesUser, REPORT_ID)).rejects.toThrow(AppError)
-
-      mockFindUniqueReport.mockResolvedValueOnce(otherUsersReport as never)
-      try {
-        await listComments(salesUser, REPORT_ID)
-      } catch (err) {
-        expect(err).toBeInstanceOf(AppError)
-        const appError = err as AppError
-        expect(appError.code).toBe('FORBIDDEN')
-        expect(appError.statusCode).toBe(403)
-      }
+      await expect(listComments(salesUser, REPORT_ID)).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      })
     })
 
     it('salesユーザーが他人の日報を指定した場合はfindManyが呼ばれない', async () => {
@@ -282,7 +266,7 @@ describe('listComments', () => {
 
       expect(mockFindUniqueReport).toHaveBeenCalledWith({
         where: { id: REPORT_ID },
-        select: { id: true, userId: true },
+        select: { userId: true },
       })
     })
 

--- a/src/lib/reports/comments.service.test.ts
+++ b/src/lib/reports/comments.service.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { listComments } from './comments.service'
+import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    dailyReport: {
+      findUnique: vi.fn(),
+    },
+    comment: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+const mockFindUniqueReport = vi.mocked(prisma.dailyReport.findUnique)
+const mockFindManyComments = vi.mocked(prisma.comment.findMany)
+
+// ─── Test users ───────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const salesUser2: AuthUser = {
+  id: '22222222-2222-2222-2222-222222222222',
+  name: '鈴木 一郎',
+  email: 'suzuki@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample data ──────────────────────────────────────────────────────────────
+
+const REPORT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+const sampleReport = {
+  id: REPORT_ID,
+  userId: salesUser.id,
+}
+
+function makePrismaComment(overrides: Partial<{
+  id: string
+  body: string
+  createdAt: Date
+  updatedAt: Date
+  commenter: { id: string; name: string; role: string }
+}> = {}) {
+  return {
+    id: overrides.id ?? 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    dailyReportId: REPORT_ID,
+    commenterId: managerUser.id,
+    body: overrides.body ?? 'コメント本文',
+    createdAt: overrides.createdAt ?? new Date('2026-04-19T18:32:00.000Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-04-19T18:32:00.000Z'),
+    commenter: overrides.commenter ?? {
+      id: managerUser.id,
+      name: managerUser.name,
+      role: 'manager',
+    },
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('listComments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── API-031: happy path ─────────────────────────────────────────────────────
+
+  describe('API-031: コメント一覧を取得できる', () => {
+    it('managerが日報のコメント一覧を取得できる', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(sampleReport as never)
+      const comment = makePrismaComment()
+      mockFindManyComments.mockResolvedValueOnce([comment] as never)
+
+      const result = await listComments(managerUser, REPORT_ID)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('dddddddd-dddd-dddd-dddd-dddddddddddd')
+      expect(result[0].body).toBe('コメント本文')
+      expect(result[0].commenter.id).toBe(managerUser.id)
+      expect(result[0].commenter.name).toBe(managerUser.name)
+      expect(result[0].commenter.role).toBe('manager')
+      expect(result[0].created_at).toBe('2026-04-19T18:32:00.000Z')
+      expect(result[0].updated_at).toBe('2026-04-19T18:32:00.000Z')
+    })
+
+    it('salesユーザーが自分の日報のコメント一覧を取得できる', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(sampleReport as never)
+      const comment = makePrismaComment()
+      mockFindManyComments.mockResolvedValueOnce([comment] as never)
+
+      const result = await listComments(salesUser, REPORT_ID)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('dddddddd-dddd-dddd-dddd-dddddddddddd')
+    })
+
+    it('adminが任意の日報のコメント一覧を取得できる', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(sampleReport as never)
+      const comment = makePrismaComment()
+      mockFindManyComments.mockResolvedValueOnce([comment] as never)
+
+      const result = await listComments(adminUser, REPORT_ID)
+
+      expect(result).toHaveLength(1)
+    })
+
+    it('コメントが0件の場合は空配列を返す', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(sampleReport as never)
+      mockFindManyComments.mockResolvedValueOnce([] as never)
+
+      const result = await listComments(managerUser, REPORT_ID)
+
+      expect(result).toHaveLength(0)
+      expect(Array.isArray(result)).toBe(true)
+    })
+  })
+
+  // ── UI-022: 投稿日時の新しい順（DESC）でソート ──────────────────────────────
+
+  describe('UI-022: コメントが投稿日時の新しい順（DESC）に返される', () => {
+    it('findManyにcreatedAt: descのorderByが渡される', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(sampleReport as never)
+      mockFindManyComments.mockResolvedValueOnce([] as never)
+
+      await listComments(managerUser, REPORT_ID)
+
+      expect(mockFindManyComments).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'desc' },
+        }),
+      )
+    })
+
+    it('新しい順に並んだコメントをそのまま返す', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(sampleReport as never)
+      const newerComment = makePrismaComment({
+        id: 'comment-newer',
+        createdAt: new Date('2026-04-19T20:00:00.000Z'),
+        updatedAt: new Date('2026-04-19T20:00:00.000Z'),
+      })
+      const olderComment = makePrismaComment({
+        id: 'comment-older',
+        createdAt: new Date('2026-04-19T10:00:00.000Z'),
+        updatedAt: new Date('2026-04-19T10:00:00.000Z'),
+      })
+      // Prismaは既にDESCでソートされた結果を返す想定
+      mockFindManyComments.mockResolvedValueOnce([newerComment, olderComment] as never)
+
+      const result = await listComments(managerUser, REPORT_ID)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('comment-newer')
+      expect(result[1].id).toBe('comment-older')
+    })
+  })
+
+  // ── 日報が存在しない場合 → NOT_FOUND ───────────────────────────────────────
+
+  describe('NOT_FOUND: 存在しない日報IDを指定すると404エラーをスローする', () => {
+    it('日報が見つからない場合はAppError.notFoundをスローする', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(null as never)
+
+      await expect(listComments(managerUser, REPORT_ID)).rejects.toThrow(AppError)
+
+      try {
+        await listComments(managerUser, REPORT_ID)
+      } catch (err) {
+        expect(err).toBeInstanceOf(AppError)
+        const appError = err as AppError
+        expect(appError.code).toBe('NOT_FOUND')
+        expect(appError.statusCode).toBe(404)
+      }
+    })
+
+    it('日報が見つからない場合はfindManyが呼ばれない', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(null as never)
+
+      await expect(listComments(managerUser, REPORT_ID)).rejects.toThrow(AppError)
+      expect(mockFindManyComments).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── salesが他人の日報のコメントを取得 → FORBIDDEN ─────────────────────────
+
+  describe('FORBIDDEN: salesユーザーが他人の日報のコメントを取得しようとすると403エラーをスローする', () => {
+    it('他人の日報に対してAppError.forbiddenをスローする', async () => {
+      // salesUser2が所有する日報（userId !== salesUser.id）
+      const otherUsersReport = {
+        id: REPORT_ID,
+        userId: salesUser2.id,
+      }
+      mockFindUniqueReport.mockResolvedValueOnce(otherUsersReport as never)
+
+      await expect(listComments(salesUser, REPORT_ID)).rejects.toThrow(AppError)
+
+      mockFindUniqueReport.mockResolvedValueOnce(otherUsersReport as never)
+      try {
+        await listComments(salesUser, REPORT_ID)
+      } catch (err) {
+        expect(err).toBeInstanceOf(AppError)
+        const appError = err as AppError
+        expect(appError.code).toBe('FORBIDDEN')
+        expect(appError.statusCode).toBe(403)
+      }
+    })
+
+    it('salesユーザーが他人の日報を指定した場合はfindManyが呼ばれない', async () => {
+      const otherUsersReport = {
+        id: REPORT_ID,
+        userId: salesUser2.id,
+      }
+      mockFindUniqueReport.mockResolvedValueOnce(otherUsersReport as never)
+
+      await expect(listComments(salesUser, REPORT_ID)).rejects.toThrow(AppError)
+      expect(mockFindManyComments).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── manager/adminは全日報にアクセス可能 ────────────────────────────────────
+
+  describe('managerは他のユーザーの日報のコメントを取得できる', () => {
+    it('managerが他salesユーザーの日報のコメントを取得できる', async () => {
+      // salesUser2が所有する日報でも、managerはアクセス可能
+      const otherUsersReport = {
+        id: REPORT_ID,
+        userId: salesUser2.id,
+      }
+      mockFindUniqueReport.mockResolvedValueOnce(otherUsersReport as never)
+      mockFindManyComments.mockResolvedValueOnce([makePrismaComment()] as never)
+
+      const result = await listComments(managerUser, REPORT_ID)
+
+      expect(result).toHaveLength(1)
+      expect(mockFindManyComments).toHaveBeenCalled()
+    })
+
+    it('adminが他salesユーザーの日報のコメントを取得できる', async () => {
+      const otherUsersReport = {
+        id: REPORT_ID,
+        userId: salesUser.id,
+      }
+      mockFindUniqueReport.mockResolvedValueOnce(otherUsersReport as never)
+      mockFindManyComments.mockResolvedValueOnce([makePrismaComment()] as never)
+
+      const result = await listComments(adminUser, REPORT_ID)
+
+      expect(result).toHaveLength(1)
+    })
+  })
+
+  // ── Prismaクエリの正確性 ────────────────────────────────────────────────────
+
+  describe('Prismaクエリ', () => {
+    it('正しいreportIdでdailyReport.findUniqueを呼ぶ', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(sampleReport as never)
+      mockFindManyComments.mockResolvedValueOnce([] as never)
+
+      await listComments(managerUser, REPORT_ID)
+
+      expect(mockFindUniqueReport).toHaveBeenCalledWith({
+        where: { id: REPORT_ID },
+        select: { id: true, userId: true },
+      })
+    })
+
+    it('正しいreportIdとcommentor includeでcomment.findManyを呼ぶ', async () => {
+      mockFindUniqueReport.mockResolvedValueOnce(sampleReport as never)
+      mockFindManyComments.mockResolvedValueOnce([] as never)
+
+      await listComments(managerUser, REPORT_ID)
+
+      expect(mockFindManyComments).toHaveBeenCalledWith({
+        where: { dailyReportId: REPORT_ID },
+        orderBy: { createdAt: 'desc' },
+        include: {
+          commenter: {
+            select: { id: true, name: true, role: true },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/lib/reports/comments.service.ts
+++ b/src/lib/reports/comments.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
-import type { AuthUser } from '@/types'
+import type { AuthUser, UserRole } from '@/types'
 
 export interface CommentItem {
   id: string
@@ -8,7 +8,7 @@ export interface CommentItem {
   commenter: {
     id: string
     name: string
-    role: string
+    role: UserRole
   }
   created_at: string
   updated_at: string
@@ -17,7 +17,7 @@ export interface CommentItem {
 export async function listComments(user: AuthUser, reportId: string): Promise<CommentItem[]> {
   const report = await prisma.dailyReport.findUnique({
     where: { id: reportId },
-    select: { id: true, userId: true },
+    select: { userId: true },
   })
 
   if (!report) {

--- a/src/lib/reports/comments.service.ts
+++ b/src/lib/reports/comments.service.ts
@@ -1,0 +1,53 @@
+import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+
+export interface CommentItem {
+  id: string
+  body: string
+  commenter: {
+    id: string
+    name: string
+    role: string
+  }
+  created_at: string
+  updated_at: string
+}
+
+export async function listComments(user: AuthUser, reportId: string): Promise<CommentItem[]> {
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    select: { id: true, userId: true },
+  })
+
+  if (!report) {
+    throw AppError.notFound('日報')
+  }
+
+  // sales role can only view comments on their own reports
+  if (user.role === 'sales' && report.userId !== user.id) {
+    throw AppError.forbidden()
+  }
+
+  const comments = await prisma.comment.findMany({
+    where: { dailyReportId: reportId },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      commenter: {
+        select: { id: true, name: true, role: true },
+      },
+    },
+  })
+
+  return comments.map((c) => ({
+    id: c.id,
+    body: c.body,
+    commenter: {
+      id: c.commenter.id,
+      name: c.commenter.name,
+      role: c.commenter.role,
+    },
+    created_at: c.createdAt.toISOString(),
+    updated_at: c.updatedAt.toISOString(),
+  }))
+}


### PR DESCRIPTION
## Summary

- `GET /reports/:report_id/comments` エンドポイントを新規実装
- 全ロール（sales/manager/admin）がアクセス可能、認証必須
- salesロールは自分の日報のコメントのみ取得可（他人の日報 → 403 FORBIDDEN）
- manager/adminは全日報のコメントを取得可
- コメントは投稿日時の新しい順（createdAt DESC）でソート
- UUID形式でないreport_idは404を返す（Prismaエラー回避）

## 実装ファイル

- `src/lib/reports/comments.service.ts` — `listComments(user, reportId)` サービス関数
- `src/app/api/reports/[id]/comments/route.ts` — GETハンドラー
- `src/lib/reports/comments.service.test.ts` — サービスユニットテスト（14ケース）
- `src/app/api/reports/[id]/comments/route.test.ts` — ルート統合テスト（11ケース）

## Test plan

- [x] 認証なし → 401 UNAUTHORIZED
- [x] salesが自分の日報 → 200, コメント一覧
- [x] managerが任意の日報 → 200, コメント一覧
- [x] adminが任意の日報 → 200, コメント一覧
- [x] コメント0件 → 200, 空配列
- [x] salesが他人の日報 → 403 FORBIDDEN
- [x] 存在しない日報ID → 404 NOT_FOUND
- [x] UUID形式でないID → 404 NOT_FOUND（サービス未呼び出し）
- [x] 予期しないエラー → 500 INTERNAL_SERVER_ERROR
- [x] createdAt DESC orderByが正しく渡される（UI-022）
- [x] `npm run test:run` 341テスト全件通過
- [x] `npx tsc --noEmit` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)