### PR TITLE
feat: Issue 15 DELETE /reports/:id/comments/:commentId コメント削除API

### DIFF
--- a/src/app/api/reports/[id]/comments/[commentId]/route.test.ts
+++ b/src/app/api/reports/[id]/comments/[commentId]/route.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { DELETE } from './route'
+import * as commentsService from '@/lib/reports/comments.service'
+import { generateToken } from '@/lib/auth/jwt'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+
+vi.mock('@/lib/reports/comments.service', () => ({
+  deleteComment: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/blacklist', () => ({
+  isBlacklisted: vi.fn().mockReturnValue(false),
+}))
+
+const mockDeleteComment = vi.mocked(commentsService.deleteComment)
+
+// ─── Test users ───────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const managerUser2: AuthUser = {
+  id: '55555555-5555-5555-5555-555555555555',
+  name: '佐藤 部長',
+  email: 'sato@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample IDs ───────────────────────────────────────────────────────────────
+
+const REPORT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+const COMMENT_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(
+  user: AuthUser,
+  reportId = REPORT_ID,
+  commentId = COMMENT_ID,
+): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/reports/${reportId}/comments/${commentId}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${generateToken(user)}`,
+      },
+    },
+  )
+}
+
+function makeRequestWithoutAuth(
+  reportId = REPORT_ID,
+  commentId = COMMENT_ID,
+): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/reports/${reportId}/comments/${commentId}`,
+    { method: 'DELETE' },
+  )
+}
+
+function makeContext(
+  reportId = REPORT_ID,
+  commentId = COMMENT_ID,
+): Record<string, unknown> {
+  return { params: { id: reportId, commentId } }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/reports/:id/comments/:commentId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Authentication ──────────────────────────────────────────────────────────
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = makeRequestWithoutAuth()
+      const res = await DELETE(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  // ── UUID validation ─────────────────────────────────────────────────────────
+
+  describe('IDバリデーション', () => {
+    it('reportIdがUUID形式でない場合は404を返す', async () => {
+      const req = makeRequest(managerUser, 'not-a-uuid', COMMENT_ID)
+      const res = await DELETE(req, makeContext('not-a-uuid', COMMENT_ID))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockDeleteComment).not.toHaveBeenCalled()
+    })
+
+    it('commentIdがUUID形式でない場合は404を返す', async () => {
+      const req = makeRequest(managerUser, REPORT_ID, 'not-a-uuid')
+      const res = await DELETE(req, makeContext(REPORT_ID, 'not-a-uuid'))
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockDeleteComment).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  describe('正常系', () => {
+    it('managerユーザーが自分のコメントを削除すると204を返す', async () => {
+      mockDeleteComment.mockResolvedValue(undefined)
+
+      const req = makeRequest(managerUser)
+      const res = await DELETE(req, makeContext())
+
+      expect(res.status).toBe(204)
+      expect(mockDeleteComment).toHaveBeenCalledWith(managerUser, REPORT_ID, COMMENT_ID)
+    })
+
+    it('adminユーザーが任意のコメントを削除すると204を返す', async () => {
+      mockDeleteComment.mockResolvedValue(undefined)
+
+      const req = makeRequest(adminUser)
+      const res = await DELETE(req, makeContext())
+
+      expect(res.status).toBe(204)
+      expect(mockDeleteComment).toHaveBeenCalledWith(adminUser, REPORT_ID, COMMENT_ID)
+    })
+  })
+
+  // ── Error cases ─────────────────────────────────────────────────────────────
+
+  describe('異常系', () => {
+    it('コメントが存在しない場合は404を返す', async () => {
+      mockDeleteComment.mockRejectedValue(AppError.notFound('コメント'))
+
+      const req = makeRequest(managerUser)
+      const res = await DELETE(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('salesユーザーがコメントを削除しようとすると403を返す', async () => {
+      mockDeleteComment.mockRejectedValue(AppError.forbidden())
+
+      const req = makeRequest(salesUser)
+      const res = await DELETE(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('他人のコメントをmanagerが削除しようとすると403を返す', async () => {
+      mockDeleteComment.mockRejectedValue(AppError.forbidden())
+
+      const req = makeRequest(managerUser2)
+      const res = await DELETE(req, makeContext())
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+})

--- a/src/app/api/reports/[id]/comments/[commentId]/route.ts
+++ b/src/app/api/reports/[id]/comments/[commentId]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/guard'
+import { deleteComment } from '@/lib/reports/comments.service'
+import { handleError } from '@/lib/errors'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+async function handleDeleteComment(
+  _req: NextRequest,
+  context: Record<string, unknown>,
+  user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const params = await (context.params as Promise<{ id: string; commentId: string }>)
+    const reportId = params.id
+    const commentId = params.commentId
+
+    if (!UUID_REGEX.test(reportId)) {
+      throw AppError.notFound('日報')
+    }
+
+    if (!UUID_REGEX.test(commentId)) {
+      throw AppError.notFound('コメント')
+    }
+
+    await deleteComment(user, reportId, commentId)
+    return new NextResponse(null, { status: 204 })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const DELETE = withAuth(handleDeleteComment)

--- a/src/lib/reports/comments.service.test.ts
+++ b/src/lib/reports/comments.service.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { listComments } from './comments.service'
+import { listComments, deleteComment } from './comments.service'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
+import { Prisma } from '@prisma/client'
 import type { AuthUser } from '@/types'
 
 vi.mock('@/lib/prisma', () => ({
@@ -11,12 +12,16 @@ vi.mock('@/lib/prisma', () => ({
     },
     comment: {
       findMany: vi.fn(),
+      findUnique: vi.fn(),
+      delete: vi.fn(),
     },
   },
 }))
 
 const mockFindUniqueReport = vi.mocked(prisma.dailyReport.findUnique)
 const mockFindManyComments = vi.mocked(prisma.comment.findMany)
+const mockFindUniqueComment = vi.mocked(prisma.comment.findUnique)
+const mockDeleteComment = vi.mocked(prisma.comment.delete)
 
 // ─── Test users ───────────────────────────────────────────────────────────────
 
@@ -286,5 +291,117 @@ describe('listComments', () => {
         },
       })
     })
+  })
+})
+
+// ─── deleteComment ────────────────────────────────────────────────────────────
+
+const COMMENT_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+
+const managerUser2: AuthUser = {
+  id: '55555555-5555-5555-5555-555555555555',
+  name: '佐藤 部長',
+  email: 'sato@test.com',
+  role: 'manager',
+}
+
+describe('deleteComment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('コメントが存在しない場合はNOT_FOUNDをスローする', async () => {
+    mockFindUniqueComment.mockResolvedValueOnce(null)
+
+    await expect(deleteComment(managerUser, REPORT_ID, COMMENT_ID)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+
+  it('コメントのdailyReportIdが一致しない場合はNOT_FOUNDをスローする', async () => {
+    mockFindUniqueComment.mockResolvedValueOnce({
+      commenterId: managerUser.id,
+      dailyReportId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+    } as never)
+
+    await expect(deleteComment(managerUser, REPORT_ID, COMMENT_ID)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+
+  it('salesユーザーがコメント削除を試みるとFORBIDDENをスローする', async () => {
+    mockFindUniqueComment.mockResolvedValueOnce({
+      commenterId: managerUser.id,
+      dailyReportId: REPORT_ID,
+    } as never)
+
+    await expect(deleteComment(salesUser, REPORT_ID, COMMENT_ID)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+  })
+
+  it('他のmanagerのコメントをmanagerが削除しようとするとFORBIDDENをスローする', async () => {
+    mockFindUniqueComment.mockResolvedValueOnce({
+      commenterId: managerUser.id,
+      dailyReportId: REPORT_ID,
+    } as never)
+
+    await expect(deleteComment(managerUser2, REPORT_ID, COMMENT_ID)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+  })
+
+  it('managerが自分のコメントを削除できる', async () => {
+    mockFindUniqueComment.mockResolvedValueOnce({
+      commenterId: managerUser.id,
+      dailyReportId: REPORT_ID,
+    } as never)
+    mockDeleteComment.mockResolvedValueOnce({} as never)
+
+    await expect(deleteComment(managerUser, REPORT_ID, COMMENT_ID)).resolves.toBeUndefined()
+    expect(mockDeleteComment).toHaveBeenCalledWith({ where: { id: COMMENT_ID } })
+  })
+
+  it('adminが他人のコメントを削除できる', async () => {
+    mockFindUniqueComment.mockResolvedValueOnce({
+      commenterId: managerUser.id,
+      dailyReportId: REPORT_ID,
+    } as never)
+    mockDeleteComment.mockResolvedValueOnce({} as never)
+
+    await expect(deleteComment(adminUser, REPORT_ID, COMMENT_ID)).resolves.toBeUndefined()
+    expect(mockDeleteComment).toHaveBeenCalledWith({ where: { id: COMMENT_ID } })
+  })
+
+  it('削除時にP2025が発生した場合はNOT_FOUNDをスローする（レースコンディション）', async () => {
+    mockFindUniqueComment.mockResolvedValueOnce({
+      commenterId: managerUser.id,
+      dailyReportId: REPORT_ID,
+    } as never)
+    const p2025 = new Prisma.PrismaClientKnownRequestError('Record not found.', {
+      code: 'P2025',
+      clientVersion: '5.0.0',
+    })
+    mockDeleteComment.mockRejectedValueOnce(p2025)
+
+    await expect(deleteComment(managerUser, REPORT_ID, COMMENT_ID)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+
+  it('P2025以外のPrismaエラーはそのまま再スローされる', async () => {
+    mockFindUniqueComment.mockResolvedValueOnce({
+      commenterId: managerUser.id,
+      dailyReportId: REPORT_ID,
+    } as never)
+    const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed.', {
+      code: 'P2002',
+      clientVersion: '5.0.0',
+    })
+    mockDeleteComment.mockRejectedValueOnce(p2002)
+
+    await expect(deleteComment(managerUser, REPORT_ID, COMMENT_ID)).rejects.toBeInstanceOf(
+      Prisma.PrismaClientKnownRequestError,
+    )
   })
 })

--- a/src/lib/reports/comments.service.test.ts
+++ b/src/lib/reports/comments.service.test.ts
@@ -338,6 +338,8 @@ describe('deleteComment', () => {
     await expect(deleteComment(salesUser, REPORT_ID, COMMENT_ID)).rejects.toMatchObject({
       code: 'FORBIDDEN',
     })
+    // salesは自分のコメントが存在する場合でも削除不可（ロールで弾く）
+    expect(mockDeleteComment).not.toHaveBeenCalled()
   })
 
   it('他のmanagerのコメントをmanagerが削除しようとするとFORBIDDENをスローする', async () => {

--- a/src/lib/reports/comments.service.ts
+++ b/src/lib/reports/comments.service.ts
@@ -67,7 +67,12 @@ export async function deleteComment(
     throw AppError.notFound('コメント')
   }
 
-  // admin can delete any comment; others can only delete their own
+  // sales cannot delete any comment
+  if (user.role === 'sales') {
+    throw AppError.forbidden()
+  }
+
+  // admin can delete any comment; manager can only delete their own
   if (user.role !== 'admin' && comment.commenterId !== user.id) {
     throw AppError.forbidden()
   }

--- a/src/lib/reports/comments.service.ts
+++ b/src/lib/reports/comments.service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser, UserRole } from '@/types'
@@ -50,4 +51,34 @@ export async function listComments(user: AuthUser, reportId: string): Promise<Co
     created_at: c.createdAt.toISOString(),
     updated_at: c.updatedAt.toISOString(),
   }))
+}
+
+export async function deleteComment(
+  user: AuthUser,
+  reportId: string,
+  commentId: string,
+): Promise<void> {
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId },
+    select: { commenterId: true, dailyReportId: true },
+  })
+
+  if (!comment || comment.dailyReportId !== reportId) {
+    throw AppError.notFound('コメント')
+  }
+
+  // admin can delete any comment; others can only delete their own
+  if (user.role !== 'admin' && comment.commenterId !== user.id) {
+    throw AppError.forbidden()
+  }
+
+  try {
+    await prisma.comment.delete({ where: { id: commentId } })
+  } catch (err) {
+    // Race condition: another request deleted the comment between our check and delete
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw AppError.notFound('コメント')
+    }
+    throw err
+  }
 }


### PR DESCRIPTION
## Summary

- `DELETE /reports/:id/comments/:commentId` エンドポイントを実装
- `deleteComment` サービス関数を `comments.service.ts` に追加
- アクセス制御: 投稿者本人（manager）または admin のみ削除可能。sales・他の manager は 403
- 日報との紐付け確認: `dailyReportId` が一致しない場合は 404
- P2025 レースコンディション対応（削除後の重複リクエスト → 404）
- 204 No Content で返却

Closes #15

## Test plan

- [ ] 認証なしリクエスト → 401
- [ ] reportId が非 UUID → 404
- [ ] commentId が非 UUID → 404
- [ ] manager が自分のコメントを削除 → 204
- [ ] admin が任意のコメントを削除 → 204
- [ ] 存在しないコメント ID → 404
- [ ] 別日報のコメント ID 指定 → 404
- [ ] sales がコメント削除を試みる → 403
- [ ] 他の manager のコメントを削除しようとする → 403
- [ ] P2025 レースコンディション → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)