### PR TITLE
feat: Issue #16 顧客マスタAPI（GET/POST/PUT /customers, GET /customers/:id）実装

### DIFF
--- a/src/app/api/customers/[id]/route.test.ts
+++ b/src/app/api/customers/[id]/route.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, PUT } from './route'
+import * as customersService from '@/lib/customers/customers.service'
+import { generateToken } from '@/lib/auth/jwt'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+import type { CustomerItem } from '@/lib/customers/customers.service'
+
+vi.mock('@/lib/customers/customers.service', () => ({
+  getCustomer: vi.fn(),
+  updateCustomer: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/blacklist', () => ({
+  isBlacklisted: vi.fn().mockReturnValue(false),
+}))
+
+const mockGetCustomer = vi.mocked(customersService.getCustomer)
+const mockUpdateCustomer = vi.mocked(customersService.updateCustomer)
+
+// ─── Test users ──────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample data ─────────────────────────────────────────────────────────────
+
+const CUSTOMER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+const sampleCustomer: CustomerItem = {
+  id: CUSTOMER_ID,
+  name: '佐藤 健',
+  company: '株式会社A',
+  phone: '03-1234-5678',
+  email: 'sato@example.com',
+  created_at: '2026-04-29T09:00:00.000Z',
+  updated_at: '2026-04-29T09:00:00.000Z',
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeGetRequest(user: AuthUser, id: string): NextRequest {
+  return new NextRequest(`http://localhost/api/customers/${id}`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${generateToken(user)}` },
+  })
+}
+
+function makePutRequest(user: AuthUser, id: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/customers/${id}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+const validUpdateBody = {
+  name: '佐藤 次郎',
+  company: '株式会社B',
+  phone: '03-9999-9999',
+  email: 'sato2@example.com',
+}
+
+// ─── GET /api/customers/[id] ─────────────────────────────────────────────────
+
+describe('GET /api/customers/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest(`http://localhost/api/customers/${CUSTOMER_ID}`, {
+        method: 'GET',
+      })
+      const res = await GET(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  describe('全ロールが顧客詳細を取得できる', () => {
+    it('salesユーザーで200を返す', async () => {
+      mockGetCustomer.mockResolvedValueOnce(sampleCustomer)
+
+      const req = makeGetRequest(salesUser, CUSTOMER_ID)
+      const res = await GET(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toMatchObject({ id: CUSTOMER_ID, name: '佐藤 健' })
+    })
+
+    it('managerユーザーで200を返す', async () => {
+      mockGetCustomer.mockResolvedValueOnce(sampleCustomer)
+
+      const req = makeGetRequest(managerUser, CUSTOMER_ID)
+      const res = await GET(req, { params: { id: CUSTOMER_ID } })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('adminユーザーで200を返す', async () => {
+      mockGetCustomer.mockResolvedValueOnce(sampleCustomer)
+
+      const req = makeGetRequest(adminUser, CUSTOMER_ID)
+      const res = await GET(req, { params: { id: CUSTOMER_ID } })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('404ケース', () => {
+    it('存在しないIDの場合は404を返す', async () => {
+      mockGetCustomer.mockRejectedValueOnce(AppError.notFound('顧客'))
+
+      const req = makeGetRequest(salesUser, CUSTOMER_ID)
+      const res = await GET(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('UUID形式でないIDの場合は404を返す', async () => {
+      const req = makeGetRequest(salesUser, 'not-a-uuid')
+      const res = await GET(req, { params: { id: 'not-a-uuid' } })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockGetCustomer).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ─── PUT /api/customers/[id] ─────────────────────────────────────────────────
+
+describe('PUT /api/customers/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest(`http://localhost/api/customers/${CUSTOMER_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validUpdateBody),
+      })
+      const res = await PUT(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  describe('API-044: 全ロールが顧客を更新できる', () => {
+    it('salesユーザーで200を返す', async () => {
+      const updatedCustomer = { ...sampleCustomer, name: '佐藤 次郎' }
+      mockUpdateCustomer.mockResolvedValueOnce(updatedCustomer)
+
+      const req = makePutRequest(salesUser, CUSTOMER_ID, validUpdateBody)
+      const res = await PUT(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data.name).toBe('佐藤 次郎')
+    })
+
+    it('managerユーザーで200を返す', async () => {
+      mockUpdateCustomer.mockResolvedValueOnce(sampleCustomer)
+
+      const req = makePutRequest(managerUser, CUSTOMER_ID, validUpdateBody)
+      const res = await PUT(req, { params: { id: CUSTOMER_ID } })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('adminユーザーで200を返す', async () => {
+      mockUpdateCustomer.mockResolvedValueOnce(sampleCustomer)
+
+      const req = makePutRequest(adminUser, CUSTOMER_ID, validUpdateBody)
+      const res = await PUT(req, { params: { id: CUSTOMER_ID } })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('バリデーション', () => {
+    it('nameが未指定の場合は400を返す', async () => {
+      const { name: _omit, ...bodyWithout } = validUpdateBody
+      const req = makePutRequest(salesUser, CUSTOMER_ID, bodyWithout)
+      const res = await PUT(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('emailが不正な形式の場合は400を返す', async () => {
+      const req = makePutRequest(salesUser, CUSTOMER_ID, { ...validUpdateBody, email: 'invalid' })
+      const res = await PUT(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  describe('404ケース', () => {
+    it('存在しないIDの場合は404を返す', async () => {
+      mockUpdateCustomer.mockRejectedValueOnce(AppError.notFound('顧客'))
+
+      const req = makePutRequest(salesUser, CUSTOMER_ID, validUpdateBody)
+      const res = await PUT(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('UUID形式でないIDの場合は404を返す', async () => {
+      const req = makePutRequest(salesUser, 'not-a-uuid', validUpdateBody)
+      const res = await PUT(req, { params: { id: 'not-a-uuid' } })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockUpdateCustomer).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockUpdateCustomer.mockRejectedValueOnce(new Error('DB error'))
+
+      const req = makePutRequest(salesUser, CUSTOMER_ID, validUpdateBody)
+      const res = await PUT(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/guard'
+import { updateCustomerSchema } from '@/lib/schemas/customer.schema'
+import { getCustomer, updateCustomer } from '@/lib/customers/customers.service'
+import { handleError } from '@/lib/errors'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+async function handleGetCustomer(
+  _req: NextRequest,
+  context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const { id } = context.params as { id: string }
+
+    if (!UUID_REGEX.test(id)) {
+      throw AppError.notFound('顧客')
+    }
+
+    const customer = await getCustomer(id)
+    return NextResponse.json({ data: customer })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const GET = withAuth(handleGetCustomer)
+
+async function handlePutCustomer(
+  req: NextRequest,
+  context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const { id } = context.params as { id: string }
+
+    if (!UUID_REGEX.test(id)) {
+      throw AppError.notFound('顧客')
+    }
+
+    const body: unknown = await req.json()
+    const input = updateCustomerSchema.parse(body)
+    const customer = await updateCustomer(id, input)
+    return NextResponse.json({ data: customer })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const PUT = withAuth(handlePutCustomer)

--- a/src/app/api/customers/route.test.ts
+++ b/src/app/api/customers/route.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, POST } from './route'
+import * as customersService from '@/lib/customers/customers.service'
+import { generateToken } from '@/lib/auth/jwt'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+import type { ListCustomersResult, CustomerItem } from '@/lib/customers/customers.service'
+
+vi.mock('@/lib/customers/customers.service', () => ({
+  listCustomers: vi.fn(),
+  createCustomer: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/blacklist', () => ({
+  isBlacklisted: vi.fn().mockReturnValue(false),
+}))
+
+const mockListCustomers = vi.mocked(customersService.listCustomers)
+const mockCreateCustomer = vi.mocked(customersService.createCustomer)
+
+// ─── Test users ──────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample data ─────────────────────────────────────────────────────────────
+
+const sampleCustomer: CustomerItem = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: '佐藤 健',
+  company: '株式会社A',
+  phone: '03-1234-5678',
+  email: 'sato@example.com',
+  created_at: '2026-04-29T09:00:00.000Z',
+  updated_at: '2026-04-29T09:00:00.000Z',
+}
+
+const defaultListResult: ListCustomersResult = {
+  data: [sampleCustomer],
+  meta: { total: 1, page: 1, per_page: 20 },
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeGetRequest(user: AuthUser, queryString = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/customers${queryString}`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${generateToken(user)}` },
+  })
+}
+
+function makePostRequest(user: AuthUser, body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/customers', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeRequestWithoutAuth(path = '/api/customers'): NextRequest {
+  return new NextRequest(`http://localhost${path}`, { method: 'GET' })
+}
+
+// ─── GET /api/customers ───────────────────────────────────────────────────────
+
+describe('GET /api/customers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = makeRequestWithoutAuth()
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  describe('API-041: 全ロールが顧客一覧を取得できる', () => {
+    it('salesユーザーで200を返す', async () => {
+      mockListCustomers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(1)
+      expect(body.meta.total).toBe(1)
+    })
+
+    it('managerユーザーで200を返す', async () => {
+      mockListCustomers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(managerUser)
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+    })
+
+    it('adminユーザーで200を返す', async () => {
+      mockListCustomers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(adminUser)
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('API-042: qパラメータで部分一致検索できる', () => {
+    it('qパラメータがlistCustomersに渡される', async () => {
+      mockListCustomers.mockResolvedValueOnce({ data: [], meta: { total: 0, page: 1, per_page: 20 } })
+
+      const req = makeGetRequest(salesUser, '?q=佐藤')
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+      expect(mockListCustomers).toHaveBeenCalledWith(
+        expect.objectContaining({ q: '佐藤' }),
+      )
+    })
+  })
+
+  describe('ページネーション', () => {
+    it('デフォルト値（page=1, per_page=20）が使われる', async () => {
+      mockListCustomers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(salesUser)
+      await GET(req, {})
+
+      expect(mockListCustomers).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, per_page: 20 }),
+      )
+    })
+
+    it('page・per_pageを指定できる', async () => {
+      mockListCustomers.mockResolvedValueOnce({ data: [], meta: { total: 0, page: 2, per_page: 10 } })
+
+      const req = makeGetRequest(salesUser, '?page=2&per_page=10')
+      await GET(req, {})
+
+      expect(mockListCustomers).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2, per_page: 10 }),
+      )
+    })
+
+    it('per_pageが101の場合は400を返す', async () => {
+      const req = makeGetRequest(salesUser, '?per_page=101')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('pageが0の場合は400を返す', async () => {
+      const req = makeGetRequest(salesUser, '?page=0')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  describe('レスポンス形式', () => {
+    it('顧客フィールドが正しく返る', async () => {
+      mockListCustomers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(body.data[0]).toMatchObject({
+        id: sampleCustomer.id,
+        name: sampleCustomer.name,
+        company: sampleCustomer.company,
+        phone: sampleCustomer.phone,
+        email: sampleCustomer.email,
+      })
+    })
+
+    it('metaにtotal・page・per_pageが含まれる', async () => {
+      mockListCustomers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(body.meta).toEqual({ total: 1, page: 1, per_page: 20 })
+    })
+  })
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockListCustomers.mockRejectedValueOnce(new Error('DB error'))
+
+      const req = makeGetRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})
+
+// ─── POST /api/customers ──────────────────────────────────────────────────────
+
+const validBody = {
+  name: '佐藤 健',
+  company: '株式会社A',
+  phone: '03-1234-5678',
+  email: 'sato@example.com',
+}
+
+describe('POST /api/customers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest('http://localhost/api/customers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validBody),
+      })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  describe('API-043: 全ロールが顧客を作成できる', () => {
+    it('salesユーザーで201を返す', async () => {
+      mockCreateCustomer.mockResolvedValueOnce(sampleCustomer)
+
+      const req = makePostRequest(salesUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(201)
+      expect(body.data).toMatchObject({ name: '佐藤 健', company: '株式会社A' })
+    })
+
+    it('managerユーザーで201を返す', async () => {
+      mockCreateCustomer.mockResolvedValueOnce(sampleCustomer)
+
+      const req = makePostRequest(managerUser, validBody)
+      const res = await POST(req, {})
+
+      expect(res.status).toBe(201)
+    })
+
+    it('adminユーザーで201を返す', async () => {
+      mockCreateCustomer.mockResolvedValueOnce(sampleCustomer)
+
+      const req = makePostRequest(adminUser, validBody)
+      const res = await POST(req, {})
+
+      expect(res.status).toBe(201)
+    })
+  })
+
+  describe('バリデーション', () => {
+    it('nameが未指定の場合は400を返す', async () => {
+      const { name: _omit, ...bodyWithout } = validBody
+      const req = makePostRequest(salesUser, bodyWithout)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('nameが101文字の場合は400を返す', async () => {
+      const req = makePostRequest(salesUser, { ...validBody, name: 'a'.repeat(101) })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('emailが不正な形式の場合は400を返す', async () => {
+      const req = makePostRequest(salesUser, { ...validBody, email: 'invalid-email' })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('必須フィールド(name)のみでも201を返す', async () => {
+      const minimalCustomer = { ...sampleCustomer, company: null, phone: null, email: null }
+      mockCreateCustomer.mockResolvedValueOnce(minimalCustomer)
+
+      const req = makePostRequest(salesUser, { name: '佐藤 健' })
+      const res = await POST(req, {})
+
+      expect(res.status).toBe(201)
+    })
+  })
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockCreateCustomer.mockRejectedValueOnce(new Error('DB error'))
+
+      const req = makePostRequest(salesUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+
+    it('AppErrorをスローした場合は対応するHTTPステータスを返す', async () => {
+      mockCreateCustomer.mockRejectedValueOnce(AppError.forbidden())
+
+      const req = makePostRequest(salesUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+})

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/guard'
+import { listCustomersQuerySchema, createCustomerSchema } from '@/lib/schemas/customer.schema'
+import { listCustomers, createCustomer } from '@/lib/customers/customers.service'
+import { handleError } from '@/lib/errors'
+import type { AuthUser } from '@/types'
+
+async function handleGetCustomers(
+  req: NextRequest,
+  _context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const searchParams = req.nextUrl.searchParams
+
+    const rawQuery: Record<string, string | undefined> = {
+      q: searchParams.get('q') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+    }
+
+    Object.keys(rawQuery).forEach((key) => {
+      if (rawQuery[key] === undefined) {
+        delete rawQuery[key]
+      }
+    })
+
+    const query = listCustomersQuerySchema.parse(rawQuery)
+    const result = await listCustomers(query)
+
+    return NextResponse.json(result)
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const GET = withAuth(handleGetCustomers)
+
+async function handlePostCustomer(
+  req: NextRequest,
+  _context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const body: unknown = await req.json()
+    const input = createCustomerSchema.parse(body)
+    const customer = await createCustomer(input)
+    return NextResponse.json({ data: customer }, { status: 201 })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const POST = withAuth(handlePostCustomer)

--- a/src/lib/customers/customers.service.test.ts
+++ b/src/lib/customers/customers.service.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { listCustomers, createCustomer, getCustomer, updateCustomer } from './customers.service'
+import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    customer: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+const mockCount = vi.mocked(prisma.customer.count)
+const mockFindMany = vi.mocked(prisma.customer.findMany)
+const mockCreate = vi.mocked(prisma.customer.create)
+const mockFindUnique = vi.mocked(prisma.customer.findUnique)
+const mockUpdate = vi.mocked(prisma.customer.update)
+
+const now = new Date('2026-04-29T09:00:00.000Z')
+
+const customerRecord = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: '佐藤 健',
+  company: '株式会社A',
+  phone: '03-1234-5678',
+  email: 'sato@example.com',
+  createdAt: now,
+  updatedAt: now,
+}
+
+const customerItem = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: '佐藤 健',
+  company: '株式会社A',
+  phone: '03-1234-5678',
+  email: 'sato@example.com',
+  created_at: now.toISOString(),
+  updated_at: now.toISOString(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ─── listCustomers ──────────────────────────────────────────────────────────
+
+describe('listCustomers', () => {
+  it('顧客一覧を返す', async () => {
+    mockCount.mockResolvedValueOnce(1)
+    mockFindMany.mockResolvedValueOnce([customerRecord] as never)
+
+    const result = await listCustomers({ q: undefined, page: 1, per_page: 20 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]).toEqual(customerItem)
+    expect(result.meta).toEqual({ total: 1, page: 1, per_page: 20 })
+  })
+
+  it('qパラメータでname/company部分一致検索する', async () => {
+    mockCount.mockResolvedValueOnce(1)
+    mockFindMany.mockResolvedValueOnce([customerRecord] as never)
+
+    await listCustomers({ q: '佐藤', page: 1, per_page: 20 })
+
+    expect(mockCount).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { name: { contains: '佐藤', mode: 'insensitive' } },
+          { company: { contains: '佐藤', mode: 'insensitive' } },
+        ],
+      },
+    })
+  })
+
+  it('qパラメータなしの場合は全件取得する', async () => {
+    mockCount.mockResolvedValueOnce(0)
+    mockFindMany.mockResolvedValueOnce([] as never)
+
+    await listCustomers({ q: undefined, page: 1, per_page: 20 })
+
+    expect(mockCount).toHaveBeenCalledWith({ where: {} })
+  })
+
+  it('ページネーションのskipが正しく計算される', async () => {
+    mockCount.mockResolvedValueOnce(50)
+    mockFindMany.mockResolvedValueOnce([] as never)
+
+    await listCustomers({ q: undefined, page: 3, per_page: 10 })
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 20, take: 10 }),
+    )
+  })
+
+  it('空の場合は空配列とtotal=0を返す', async () => {
+    mockCount.mockResolvedValueOnce(0)
+    mockFindMany.mockResolvedValueOnce([] as never)
+
+    const result = await listCustomers({ q: undefined, page: 1, per_page: 20 })
+
+    expect(result.data).toEqual([])
+    expect(result.meta.total).toBe(0)
+  })
+})
+
+// ─── createCustomer ─────────────────────────────────────────────────────────
+
+describe('createCustomer', () => {
+  it('顧客を作成して返す', async () => {
+    mockCreate.mockResolvedValueOnce(customerRecord as never)
+
+    const result = await createCustomer({
+      name: '佐藤 健',
+      company: '株式会社A',
+      phone: '03-1234-5678',
+      email: 'sato@example.com',
+    })
+
+    expect(result).toEqual(customerItem)
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        name: '佐藤 健',
+        company: '株式会社A',
+        phone: '03-1234-5678',
+        email: 'sato@example.com',
+      },
+    })
+  })
+
+  it('オプションフィールドが未指定の場合もcreateを呼ぶ', async () => {
+    const minimalRecord = { ...customerRecord, company: null, phone: null, email: null }
+    mockCreate.mockResolvedValueOnce(minimalRecord as never)
+
+    const result = await createCustomer({ name: '佐藤 健' })
+
+    expect(result.company).toBeNull()
+    expect(result.phone).toBeNull()
+    expect(result.email).toBeNull()
+  })
+})
+
+// ─── getCustomer ────────────────────────────────────────────────────────────
+
+describe('getCustomer', () => {
+  it('存在する顧客を返す', async () => {
+    mockFindUnique.mockResolvedValueOnce(customerRecord as never)
+
+    const result = await getCustomer('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+    expect(result).toEqual(customerItem)
+  })
+
+  it('存在しないIDの場合は404 AppErrorをスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+
+    await expect(getCustomer('ffffffff-ffff-ffff-ffff-ffffffffffff')).rejects.toThrow(AppError)
+    await expect(getCustomer('ffffffff-ffff-ffff-ffff-ffffffffffff')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+})
+
+// ─── updateCustomer ─────────────────────────────────────────────────────────
+
+describe('updateCustomer', () => {
+  it('顧客を更新して返す', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: customerRecord.id } as never)
+    const updated = { ...customerRecord, name: '佐藤 次郎' }
+    mockUpdate.mockResolvedValueOnce(updated as never)
+
+    const result = await updateCustomer('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', {
+      name: '佐藤 次郎',
+      company: '株式会社A',
+      phone: '03-1234-5678',
+      email: 'sato@example.com',
+    })
+
+    expect(result.name).toBe('佐藤 次郎')
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' },
+      data: {
+        name: '佐藤 次郎',
+        company: '株式会社A',
+        phone: '03-1234-5678',
+        email: 'sato@example.com',
+      },
+    })
+  })
+
+  it('存在しないIDの場合は404 AppErrorをスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+
+    await expect(
+      updateCustomer('ffffffff-ffff-ffff-ffff-ffffffffffff', { name: '佐藤 次郎' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+})

--- a/src/lib/customers/customers.service.test.ts
+++ b/src/lib/customers/customers.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Prisma } from '@prisma/client'
 import { listCustomers, createCustomer, getCustomer, updateCustomer } from './customers.service'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
@@ -197,6 +198,19 @@ describe('updateCustomer', () => {
 
     await expect(
       updateCustomer('ffffffff-ffff-ffff-ffff-ffffffffffff', { name: '佐藤 次郎' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('レースコンディション: findUniqueとupdateの間に削除された場合は404をスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: customerRecord.id } as never)
+    const p2025Error = new Prisma.PrismaClientKnownRequestError('Record not found', {
+      code: 'P2025',
+      clientVersion: '5.0.0',
+    })
+    mockUpdate.mockRejectedValueOnce(p2025Error)
+
+    await expect(
+      updateCustomer('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', { name: '佐藤 次郎' }),
     ).rejects.toMatchObject({ code: 'NOT_FOUND' })
   })
 })

--- a/src/lib/customers/customers.service.ts
+++ b/src/lib/customers/customers.service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
 import type { CreateCustomerInput, UpdateCustomerInput, ListCustomersQuery } from '@/lib/schemas/customer.schema'
@@ -107,15 +108,22 @@ export async function updateCustomer(
     throw AppError.notFound('顧客')
   }
 
-  const customer = await prisma.customer.update({
-    where: { id: customerId },
-    data: {
-      name: input.name,
-      company: input.company,
-      phone: input.phone,
-      email: input.email,
-    },
-  })
-
-  return formatCustomer(customer)
+  try {
+    const customer = await prisma.customer.update({
+      where: { id: customerId },
+      data: {
+        name: input.name,
+        company: input.company,
+        phone: input.phone,
+        email: input.email,
+      },
+    })
+    return formatCustomer(customer)
+  } catch (err) {
+    // Race condition: customer was deleted between the existence check and the update
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw AppError.notFound('顧客')
+    }
+    throw err
+  }
 }

--- a/src/lib/customers/customers.service.ts
+++ b/src/lib/customers/customers.service.ts
@@ -1,0 +1,121 @@
+import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
+import type { CreateCustomerInput, UpdateCustomerInput, ListCustomersQuery } from '@/lib/schemas/customer.schema'
+
+export interface CustomerItem {
+  id: string
+  name: string
+  company: string | null
+  phone: string | null
+  email: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ListCustomersResult {
+  data: CustomerItem[]
+  meta: {
+    total: number
+    page: number
+    per_page: number
+  }
+}
+
+function formatCustomer(customer: {
+  id: string
+  name: string
+  company: string | null
+  phone: string | null
+  email: string | null
+  createdAt: Date
+  updatedAt: Date
+}): CustomerItem {
+  return {
+    id: customer.id,
+    name: customer.name,
+    company: customer.company,
+    phone: customer.phone,
+    email: customer.email,
+    created_at: customer.createdAt.toISOString(),
+    updated_at: customer.updatedAt.toISOString(),
+  }
+}
+
+export async function listCustomers(query: ListCustomersQuery): Promise<ListCustomersResult> {
+  const { q, page, per_page } = query
+  const skip = (page - 1) * per_page
+
+  const where = q
+    ? {
+        OR: [
+          { name: { contains: q, mode: 'insensitive' as const } },
+          { company: { contains: q, mode: 'insensitive' as const } },
+        ],
+      }
+    : {}
+
+  const [total, customers] = await Promise.all([
+    prisma.customer.count({ where }),
+    prisma.customer.findMany({
+      where,
+      skip,
+      take: per_page,
+      orderBy: { createdAt: 'asc' },
+    }),
+  ])
+
+  return {
+    data: customers.map(formatCustomer),
+    meta: { total, page, per_page },
+  }
+}
+
+export async function createCustomer(input: CreateCustomerInput): Promise<CustomerItem> {
+  const customer = await prisma.customer.create({
+    data: {
+      name: input.name,
+      company: input.company,
+      phone: input.phone,
+      email: input.email,
+    },
+  })
+  return formatCustomer(customer)
+}
+
+export async function getCustomer(customerId: string): Promise<CustomerItem> {
+  const customer = await prisma.customer.findUnique({
+    where: { id: customerId },
+  })
+
+  if (!customer) {
+    throw AppError.notFound('顧客')
+  }
+
+  return formatCustomer(customer)
+}
+
+export async function updateCustomer(
+  customerId: string,
+  input: UpdateCustomerInput,
+): Promise<CustomerItem> {
+  const existing = await prisma.customer.findUnique({
+    where: { id: customerId },
+    select: { id: true },
+  })
+
+  if (!existing) {
+    throw AppError.notFound('顧客')
+  }
+
+  const customer = await prisma.customer.update({
+    where: { id: customerId },
+    data: {
+      name: input.name,
+      company: input.company,
+      phone: input.phone,
+      email: input.email,
+    },
+  })
+
+  return formatCustomer(customer)
+}

--- a/src/lib/schemas/customer.schema.ts
+++ b/src/lib/schemas/customer.schema.ts
@@ -26,3 +26,25 @@ export const updateCustomerSchema = customerBaseSchema
 
 export type CreateCustomerInput = z.infer<typeof createCustomerSchema>
 export type UpdateCustomerInput = z.infer<typeof updateCustomerSchema>
+
+export const listCustomersQuerySchema = z.object({
+  q: z.string().optional(),
+  page: z
+    .string()
+    .optional()
+    .transform((val) => (val !== undefined ? parseInt(val, 10) : 1))
+    .pipe(z.number().int().min(1, 'pageは1以上で指定してください')),
+  per_page: z
+    .string()
+    .optional()
+    .transform((val) => (val !== undefined ? parseInt(val, 10) : 20))
+    .pipe(
+      z
+        .number()
+        .int()
+        .min(1, 'per_pageは1以上で指定してください')
+        .max(100, 'per_pageは100以下で指定してください'),
+    ),
+})
+
+export type ListCustomersQuery = z.infer<typeof listCustomersQuerySchema>


### PR DESCRIPTION
## Summary
- GET /customers: 顧客一覧取得・検索API（ページネーション・`q`パラメータによるname/company部分一致検索対応）
- POST /customers: 顧客新規登録API（全ロール可、Zodバリデーション）
- GET /customers/:id: 顧客詳細取得API（UUID形式チェック付き）
- PUT /customers/:id: 顧客更新API（全ロール可、UUID形式チェック付き）

## Test plan
- [x] GET /customers 一覧取得テスト（全ロール200）
- [x] GET /customers?q= 部分一致検索テスト
- [x] GET /customers ページネーション（デフォルト値・上下限境界値）テスト
- [x] POST /customers 新規登録テスト（全ロール201）
- [x] POST /customers バリデーションエラー400テスト
- [x] GET /customers/:id 詳細取得テスト（全ロール200）
- [x] GET /customers/:id 存在しないID 404テスト
- [x] GET /customers/:id UUID形式でないID 404テスト
- [x] PUT /customers/:id 更新テスト（全ロール200）
- [x] PUT /customers/:id 存在しないID 404テスト
- [x] PUT /customers/:id バリデーションエラー400テスト
- [x] 未認証401テスト（全エンドポイント）
- [x] customers.service.ts ユニットテスト（listCustomers・createCustomer・getCustomer・updateCustomer）

全372テスト通過確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)