### PR TITLE
feat: Issue 17 DELETE /customers/:id 顧客削除API

### DIFF
--- a/src/app/api/customers/[id]/route.test.ts
+++ b/src/app/api/customers/[id]/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
-import { GET, PUT } from './route'
+import { GET, PUT, DELETE } from './route'
 import * as customersService from '@/lib/customers/customers.service'
 import { generateToken } from '@/lib/auth/jwt'
 import { AppError } from '@/lib/errors/AppError'
@@ -10,6 +10,7 @@ import type { CustomerItem } from '@/lib/customers/customers.service'
 vi.mock('@/lib/customers/customers.service', () => ({
   getCustomer: vi.fn(),
   updateCustomer: vi.fn(),
+  deleteCustomer: vi.fn(),
 }))
 
 vi.mock('@/lib/auth/blacklist', () => ({
@@ -18,6 +19,7 @@ vi.mock('@/lib/auth/blacklist', () => ({
 
 const mockGetCustomer = vi.mocked(customersService.getCustomer)
 const mockUpdateCustomer = vi.mocked(customersService.updateCustomer)
+const mockDeleteCustomer = vi.mocked(customersService.deleteCustomer)
 
 // ─── Test users ──────────────────────────────────────────────────────────────
 
@@ -266,6 +268,110 @@ describe('PUT /api/customers/[id]', () => {
 
       expect(res.status).toBe(500)
       expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})
+
+// ─── DELETE /api/customers/:id ────────────────────────────────────────────────
+
+describe('DELETE /api/customers/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function makeDeleteRequest(user: AuthUser, customerId = CUSTOMER_ID): NextRequest {
+    return new NextRequest(`http://localhost/api/customers/${customerId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${generateToken(user)}` },
+    })
+  }
+
+  // ── 認証 ──────────────────────────────────────────────────────────────────
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest(`http://localhost/api/customers/${CUSTOMER_ID}`, {
+        method: 'DELETE',
+      })
+      const res = await DELETE(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('admin以外（sales）は403を返す', async () => {
+      const req = makeDeleteRequest(salesUser)
+      const res = await DELETE(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+      expect(mockDeleteCustomer).not.toHaveBeenCalled()
+    })
+
+    it('admin以外（manager）は403を返す', async () => {
+      const req = makeDeleteRequest(managerUser)
+      const res = await DELETE(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+      expect(mockDeleteCustomer).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── UUID バリデーション ────────────────────────────────────────────────────
+
+  describe('IDバリデーション', () => {
+    it('UUID形式でないIDは404を返す', async () => {
+      const req = makeDeleteRequest(adminUser, 'not-a-uuid')
+      const res = await DELETE(req, { params: { id: 'not-a-uuid' } })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockDeleteCustomer).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── 正常系 ────────────────────────────────────────────────────────────────
+
+  describe('正常系', () => {
+    it('adminが顧客を削除すると204を返す', async () => {
+      mockDeleteCustomer.mockResolvedValueOnce(undefined)
+
+      const req = makeDeleteRequest(adminUser)
+      const res = await DELETE(req, { params: { id: CUSTOMER_ID } })
+
+      expect(res.status).toBe(204)
+      expect(mockDeleteCustomer).toHaveBeenCalledWith(CUSTOMER_ID)
+    })
+  })
+
+  // ── 異常系 ────────────────────────────────────────────────────────────────
+
+  describe('異常系', () => {
+    it('顧客が存在しない場合は404を返す', async () => {
+      mockDeleteCustomer.mockRejectedValueOnce(AppError.notFound('顧客'))
+
+      const req = makeDeleteRequest(adminUser)
+      const res = await DELETE(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('訪問記録に紐づいている顧客は409を返す', async () => {
+      mockDeleteCustomer.mockRejectedValueOnce(AppError.customerInUse())
+
+      const req = makeDeleteRequest(adminUser)
+      const res = await DELETE(req, { params: { id: CUSTOMER_ID } })
+      const body = await res.json()
+
+      expect(res.status).toBe(409)
+      expect(body.error.code).toBe('CUSTOMER_IN_USE')
     })
   })
 })

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth } from '@/lib/auth/guard'
 import { updateCustomerSchema } from '@/lib/schemas/customer.schema'
-import { getCustomer, updateCustomer } from '@/lib/customers/customers.service'
+import { getCustomer, updateCustomer, deleteCustomer } from '@/lib/customers/customers.service'
 import { handleError } from '@/lib/errors'
 import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
@@ -51,3 +51,24 @@ async function handlePutCustomer(
 }
 
 export const PUT = withAuth(handlePutCustomer)
+
+async function handleDeleteCustomer(
+  _req: NextRequest,
+  context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const { id } = context.params as { id: string }
+
+    if (!UUID_REGEX.test(id)) {
+      throw AppError.notFound('顧客')
+    }
+
+    await deleteCustomer(id)
+    return new NextResponse(null, { status: 204 })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const DELETE = withAuth(handleDeleteCustomer, ['admin'])

--- a/src/lib/customers/customers.service.test.ts
+++ b/src/lib/customers/customers.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Prisma } from '@prisma/client'
-import { listCustomers, createCustomer, getCustomer, updateCustomer } from './customers.service'
+import { listCustomers, createCustomer, getCustomer, updateCustomer, deleteCustomer } from './customers.service'
 import { prisma } from '@/lib/prisma'
 import { AppError } from '@/lib/errors/AppError'
 
@@ -12,6 +12,10 @@ vi.mock('@/lib/prisma', () => ({
       create: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      delete: vi.fn(),
+    },
+    visitRecord: {
+      count: vi.fn(),
     },
   },
 }))
@@ -21,6 +25,8 @@ const mockFindMany = vi.mocked(prisma.customer.findMany)
 const mockCreate = vi.mocked(prisma.customer.create)
 const mockFindUnique = vi.mocked(prisma.customer.findUnique)
 const mockUpdate = vi.mocked(prisma.customer.update)
+const mockDelete = vi.mocked(prisma.customer.delete)
+const mockVisitRecordCount = vi.mocked(prisma.visitRecord.count)
 
 const now = new Date('2026-04-29T09:00:00.000Z')
 
@@ -212,5 +218,73 @@ describe('updateCustomer', () => {
     await expect(
       updateCustomer('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', { name: '佐藤 次郎' }),
     ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+})
+
+describe('deleteCustomer', () => {
+  const CUSTOMER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('顧客が存在しない場合はNOT_FOUNDをスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+
+    await expect(deleteCustomer(CUSTOMER_ID)).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(mockVisitRecordCount).not.toHaveBeenCalled()
+  })
+
+  it('訪問記録に紐づいている場合はCUSTOMER_IN_USEをスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: CUSTOMER_ID } as never)
+    mockVisitRecordCount.mockResolvedValueOnce(3)
+
+    await expect(deleteCustomer(CUSTOMER_ID)).rejects.toMatchObject({ code: 'CUSTOMER_IN_USE' })
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it('参照のない顧客を正常に削除できる', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: CUSTOMER_ID } as never)
+    mockVisitRecordCount.mockResolvedValueOnce(0)
+    mockDelete.mockResolvedValueOnce({} as never)
+
+    await expect(deleteCustomer(CUSTOMER_ID)).resolves.toBeUndefined()
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: CUSTOMER_ID } })
+  })
+
+  it('visitRecord.countに正しいcustomerIdが渡される', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: CUSTOMER_ID } as never)
+    mockVisitRecordCount.mockResolvedValueOnce(0)
+    mockDelete.mockResolvedValueOnce({} as never)
+
+    await deleteCustomer(CUSTOMER_ID)
+
+    expect(mockVisitRecordCount).toHaveBeenCalledWith({ where: { customerId: CUSTOMER_ID } })
+  })
+
+  it('削除時にP2025が発生した場合はNOT_FOUNDをスローする（レースコンディション）', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: CUSTOMER_ID } as never)
+    mockVisitRecordCount.mockResolvedValueOnce(0)
+    const p2025 = new Prisma.PrismaClientKnownRequestError('Record not found.', {
+      code: 'P2025',
+      clientVersion: '5.0.0',
+    })
+    mockDelete.mockRejectedValueOnce(p2025)
+
+    await expect(deleteCustomer(CUSTOMER_ID)).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('P2025以外のPrismaエラーはそのまま再スローされる', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: CUSTOMER_ID } as never)
+    mockVisitRecordCount.mockResolvedValueOnce(0)
+    const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed.', {
+      code: 'P2002',
+      clientVersion: '5.0.0',
+    })
+    mockDelete.mockRejectedValueOnce(p2002)
+
+    await expect(deleteCustomer(CUSTOMER_ID)).rejects.toBeInstanceOf(
+      Prisma.PrismaClientKnownRequestError,
+    )
   })
 })

--- a/src/lib/customers/customers.service.test.ts
+++ b/src/lib/customers/customers.service.test.ts
@@ -274,7 +274,19 @@ describe('deleteCustomer', () => {
     await expect(deleteCustomer(CUSTOMER_ID)).rejects.toMatchObject({ code: 'NOT_FOUND' })
   })
 
-  it('P2025以外のPrismaエラーはそのまま再スローされる', async () => {
+  it('削除時にP2003が発生した場合はCUSTOMER_IN_USEをスローする（レースコンディション）', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: CUSTOMER_ID } as never)
+    mockVisitRecordCount.mockResolvedValueOnce(0)
+    const p2003 = new Prisma.PrismaClientKnownRequestError('Foreign key constraint failed.', {
+      code: 'P2003',
+      clientVersion: '5.0.0',
+    })
+    mockDelete.mockRejectedValueOnce(p2003)
+
+    await expect(deleteCustomer(CUSTOMER_ID)).rejects.toMatchObject({ code: 'CUSTOMER_IN_USE' })
+  })
+
+  it('P2025/P2003以外のPrismaエラーはそのまま再スローされる', async () => {
     mockFindUnique.mockResolvedValueOnce({ id: CUSTOMER_ID } as never)
     mockVisitRecordCount.mockResolvedValueOnce(0)
     const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed.', {

--- a/src/lib/customers/customers.service.ts
+++ b/src/lib/customers/customers.service.ts
@@ -127,3 +127,32 @@ export async function updateCustomer(
     throw err
   }
 }
+
+export async function deleteCustomer(customerId: string): Promise<void> {
+  const customer = await prisma.customer.findUnique({
+    where: { id: customerId },
+    select: { id: true },
+  })
+
+  if (!customer) {
+    throw AppError.notFound('顧客')
+  }
+
+  const visitRecordCount = await prisma.visitRecord.count({
+    where: { customerId },
+  })
+
+  if (visitRecordCount > 0) {
+    throw AppError.customerInUse()
+  }
+
+  try {
+    await prisma.customer.delete({ where: { id: customerId } })
+  } catch (err) {
+    // Race condition: customer was deleted between our check and delete
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw AppError.notFound('顧客')
+    }
+    throw err
+  }
+}

--- a/src/lib/customers/customers.service.ts
+++ b/src/lib/customers/customers.service.ts
@@ -149,9 +149,11 @@ export async function deleteCustomer(customerId: string): Promise<void> {
   try {
     await prisma.customer.delete({ where: { id: customerId } })
   } catch (err) {
-    // Race condition: customer was deleted between our check and delete
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
-      throw AppError.notFound('顧客')
+    if (err instanceof Prisma.PrismaClientKnownRequestError) {
+      // Race condition: customer was deleted between our check and delete
+      if (err.code === 'P2025') throw AppError.notFound('顧客')
+      // Race condition: visit record was added between our count check and delete
+      if (err.code === 'P2003') throw AppError.customerInUse()
     }
     throw err
   }


### PR DESCRIPTION
## Summary

- `DELETE /customers/:id` エンドポイントを実装
- `deleteCustomer` サービス関数を `customers.service.ts` に追加
- アクセス制御: `admin` ロールのみ（`withAuth(['admin'])` で制御）
- 訪問記録に紐づいている顧客は削除不可 → 409 CUSTOMER_IN_USE
- 存在しない顧客 → 404 NOT_FOUND
- P2025 レースコンディション対応
- 204 No Content で返却

Closes #17

## Test plan

- [ ] 認証なしリクエスト → 401
- [ ] sales でリクエスト → 403
- [ ] manager でリクエスト → 403
- [ ] 非 UUID 形式の ID → 404
- [ ] admin + 参照のない顧客 → 204
- [ ] admin + 存在しない顧客 → 404
- [ ] admin + 訪問記録ありの顧客 → 409 CUSTOMER_IN_USE
- [ ] P2025 レースコンディション → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)