### PR TITLE
feat: Issue 18 ユーザーAPI（GET/POST/PUT/DELETE /users）実装

### DIFF
--- a/src/app/api/users/[id]/route.test.ts
+++ b/src/app/api/users/[id]/route.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, PUT, DELETE } from './route'
+import * as usersService from '@/lib/users/users.service'
+import { generateToken } from '@/lib/auth/jwt'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+import type { UserItem } from '@/lib/users/users.service'
+
+vi.mock('@/lib/users/users.service', () => ({
+  getUser: vi.fn(),
+  updateUser: vi.fn(),
+  deleteUser: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/blacklist', () => ({
+  isBlacklisted: vi.fn().mockReturnValue(false),
+}))
+
+const mockGetUser = vi.mocked(usersService.getUser)
+const mockUpdateUser = vi.mocked(usersService.updateUser)
+const mockDeleteUser = vi.mocked(usersService.deleteUser)
+
+// ─── Test users ──────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample data ─────────────────────────────────────────────────────────────
+
+const USER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+const sampleUser: UserItem = {
+  id: USER_ID,
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+  created_at: '2026-04-29T09:00:00.000Z',
+  updated_at: '2026-04-29T09:00:00.000Z',
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeGetRequest(user: AuthUser, id = USER_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/users/${id}`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${generateToken(user)}` },
+  })
+}
+
+function makePutRequest(user: AuthUser, id: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/users/${id}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeDeleteRequest(user: AuthUser, id = USER_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/users/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${generateToken(user)}` },
+  })
+}
+
+const validUpdateBody = {
+  name: '山田 次郎',
+  email: 'yamada2@test.com',
+  role: 'manager',
+}
+
+// ─── GET /api/users/[id] ─────────────────────────────────────────────────────
+
+describe('GET /api/users/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest(`http://localhost/api/users/${USER_ID}`, { method: 'GET' })
+      const res = await GET(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  describe('USR-003: adminは任意のユーザーを取得できる', () => {
+    it('adminで200を返す', async () => {
+      mockGetUser.mockResolvedValueOnce(sampleUser)
+
+      const req = makeGetRequest(adminUser)
+      const res = await GET(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toMatchObject({ id: USER_ID, name: '山田 太郎' })
+    })
+  })
+
+  describe('本人はアクセス可能', () => {
+    it('salesユーザーが自分のプロフィールを取得できる', async () => {
+      mockGetUser.mockResolvedValueOnce(sampleUser)
+
+      const req = makeGetRequest(salesUser, salesUser.id)
+      const res = await GET(req, { params: Promise.resolve({ id: salesUser.id }) })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('他人のプロフィール → FORBIDDENはservice層で処理', () => {
+    it('serviceがFORBIDDENを投げた場合は403を返す', async () => {
+      mockGetUser.mockRejectedValueOnce(AppError.forbidden())
+
+      const req = makeGetRequest(salesUser)
+      const res = await GET(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  describe('404ケース', () => {
+    it('存在しないIDの場合は404を返す', async () => {
+      mockGetUser.mockRejectedValueOnce(AppError.notFound('ユーザー'))
+
+      const req = makeGetRequest(adminUser)
+      const res = await GET(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('UUID形式でないIDは404を返す', async () => {
+      const req = makeGetRequest(adminUser, 'not-a-uuid')
+      const res = await GET(req, { params: Promise.resolve({ id: 'not-a-uuid' }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockGetUser).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ─── PUT /api/users/[id] ─────────────────────────────────────────────────────
+
+describe('PUT /api/users/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証・認可', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest(`http://localhost/api/users/${USER_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validUpdateBody),
+      })
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('salesユーザーは403を返す', async () => {
+      const req = makePutRequest(salesUser, USER_ID, validUpdateBody)
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('managerユーザーは403を返す', async () => {
+      const req = makePutRequest(managerUser, USER_ID, validUpdateBody)
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  describe('USR-004: adminがユーザーを更新できる', () => {
+    it('200と更新されたユーザーを返す', async () => {
+      const updated = { ...sampleUser, name: '山田 次郎' }
+      mockUpdateUser.mockResolvedValueOnce(updated)
+
+      const req = makePutRequest(adminUser, USER_ID, validUpdateBody)
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data.name).toBe('山田 次郎')
+    })
+  })
+
+  describe('バリデーション', () => {
+    it('nameが未指定の場合は400を返す', async () => {
+      const { name: _omit, ...body } = validUpdateBody
+      const req = makePutRequest(adminUser, USER_ID, body)
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const resBody = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(resBody.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('emailが不正な形式の場合は400を返す', async () => {
+      const req = makePutRequest(adminUser, USER_ID, { ...validUpdateBody, email: 'invalid' })
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('passwordが7文字の場合は400を返す', async () => {
+      const req = makePutRequest(adminUser, USER_ID, { ...validUpdateBody, password: '1234567' })
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('passwordは省略可能（200を返す）', async () => {
+      mockUpdateUser.mockResolvedValueOnce(sampleUser)
+
+      const req = makePutRequest(adminUser, USER_ID, validUpdateBody)
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('404・409ケース', () => {
+    it('UUID形式でないIDは404を返す', async () => {
+      const req = makePutRequest(adminUser, 'not-a-uuid', validUpdateBody)
+      const res = await PUT(req, { params: Promise.resolve({ id: 'not-a-uuid' }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockUpdateUser).not.toHaveBeenCalled()
+    })
+
+    it('存在しないIDの場合は404を返す', async () => {
+      mockUpdateUser.mockRejectedValueOnce(AppError.notFound('ユーザー'))
+
+      const req = makePutRequest(adminUser, USER_ID, validUpdateBody)
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('メールアドレス重複の場合は409を返す', async () => {
+      mockUpdateUser.mockRejectedValueOnce(AppError.emailAlreadyExists())
+
+      const req = makePutRequest(adminUser, USER_ID, validUpdateBody)
+      const res = await PUT(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(409)
+      expect(body.error.code).toBe('EMAIL_ALREADY_EXISTS')
+    })
+  })
+})
+
+// ─── DELETE /api/users/[id] ──────────────────────────────────────────────────
+
+describe('DELETE /api/users/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証・認可', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest(`http://localhost/api/users/${USER_ID}`, { method: 'DELETE' })
+      const res = await DELETE(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('salesユーザーは403を返す', async () => {
+      const req = makeDeleteRequest(salesUser)
+      const res = await DELETE(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+      expect(mockDeleteUser).not.toHaveBeenCalled()
+    })
+
+    it('managerユーザーは403を返す', async () => {
+      const req = makeDeleteRequest(managerUser)
+      const res = await DELETE(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+      expect(mockDeleteUser).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('IDバリデーション', () => {
+    it('UUID形式でないIDは404を返す', async () => {
+      const req = makeDeleteRequest(adminUser, 'not-a-uuid')
+      const res = await DELETE(req, { params: Promise.resolve({ id: 'not-a-uuid' }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+      expect(mockDeleteUser).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('USR-006: adminがユーザーを削除できる', () => {
+    it('adminが参照のないユーザーを削除すると204を返す', async () => {
+      mockDeleteUser.mockResolvedValueOnce(undefined)
+
+      const req = makeDeleteRequest(adminUser)
+      const res = await DELETE(req, { params: Promise.resolve({ id: USER_ID }) })
+
+      expect(res.status).toBe(204)
+      expect(mockDeleteUser).toHaveBeenCalledWith(USER_ID)
+    })
+  })
+
+  describe('異常系', () => {
+    it('存在しないIDの場合は404を返す', async () => {
+      mockDeleteUser.mockRejectedValueOnce(AppError.notFound('ユーザー'))
+
+      const req = makeDeleteRequest(adminUser)
+      const res = await DELETE(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(404)
+      expect(body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('日報に紐づいているユーザーは409を返す', async () => {
+      mockDeleteUser.mockRejectedValueOnce(AppError.userInUse())
+
+      const req = makeDeleteRequest(adminUser)
+      const res = await DELETE(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(409)
+      expect(body.error.code).toBe('USER_IN_USE')
+    })
+
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockDeleteUser.mockRejectedValueOnce(new Error('DB error'))
+
+      const req = makeDeleteRequest(adminUser)
+      const res = await DELETE(req, { params: Promise.resolve({ id: USER_ID }) })
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/guard'
+import { updateUserSchema } from '@/lib/schemas/user.schema'
+import { getUser, updateUser, deleteUser } from '@/lib/users/users.service'
+import { handleError } from '@/lib/errors'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+async function handleGetUser(
+  _req: NextRequest,
+  context: Record<string, unknown>,
+  user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const params = await (context.params as Promise<{ id: string }>)
+    const userId = params.id
+
+    if (!UUID_REGEX.test(userId)) {
+      throw AppError.notFound('ユーザー')
+    }
+
+    const data = await getUser(userId, user)
+    return NextResponse.json({ data })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+// GET /users/:id is accessible by admin or the user themselves
+export const GET = withAuth(handleGetUser)
+
+async function handlePutUser(
+  req: NextRequest,
+  context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const params = await (context.params as Promise<{ id: string }>)
+    const userId = params.id
+
+    if (!UUID_REGEX.test(userId)) {
+      throw AppError.notFound('ユーザー')
+    }
+
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      throw new Error('Invalid JSON')
+    }
+    const input = updateUserSchema.parse(body)
+    const data = await updateUser(userId, input)
+    return NextResponse.json({ data })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const PUT = withAuth(handlePutUser, ['admin'])
+
+async function handleDeleteUser(
+  _req: NextRequest,
+  context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const params = await (context.params as Promise<{ id: string }>)
+    const userId = params.id
+
+    if (!UUID_REGEX.test(userId)) {
+      throw AppError.notFound('ユーザー')
+    }
+
+    await deleteUser(userId)
+    return new NextResponse(null, { status: 204 })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const DELETE = withAuth(handleDeleteUser, ['admin'])

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -48,7 +48,7 @@ async function handlePutUser(
     try {
       body = await req.json()
     } catch {
-      throw new Error('Invalid JSON')
+      throw AppError.validationError('リクエストボディが不正なJSON形式です')
     }
     const input = updateUserSchema.parse(body)
     const data = await updateUser(userId, input)

--- a/src/app/api/users/route.test.ts
+++ b/src/app/api/users/route.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, POST } from './route'
+import * as usersService from '@/lib/users/users.service'
+import { generateToken } from '@/lib/auth/jwt'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+import type { ListUsersResult, UserItem } from '@/lib/users/users.service'
+
+vi.mock('@/lib/users/users.service', () => ({
+  listUsers: vi.fn(),
+  createUser: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/blacklist', () => ({
+  isBlacklisted: vi.fn().mockReturnValue(false),
+}))
+
+const mockListUsers = vi.mocked(usersService.listUsers)
+const mockCreateUser = vi.mocked(usersService.createUser)
+
+// ─── Test users ──────────────────────────────────────────────────────────────
+
+const salesUser: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const managerUser: AuthUser = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+// ─── Sample data ─────────────────────────────────────────────────────────────
+
+const sampleUser: UserItem = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+  created_at: '2026-04-29T09:00:00.000Z',
+  updated_at: '2026-04-29T09:00:00.000Z',
+}
+
+const defaultListResult: ListUsersResult = {
+  data: [sampleUser],
+  meta: { total: 1, page: 1, per_page: 20 },
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeGetRequest(user: AuthUser, queryString = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/users${queryString}`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${generateToken(user)}` },
+  })
+}
+
+function makePostRequest(user: AuthUser, body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/users', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${generateToken(user)}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+const validBody = {
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  password: 'Test1234!',
+  role: 'sales',
+}
+
+// ─── GET /api/users ───────────────────────────────────────────────────────────
+
+describe('GET /api/users', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証・認可', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest('http://localhost/api/users', { method: 'GET' })
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('salesユーザーは403を返す', async () => {
+      const req = makeGetRequest(salesUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('managerユーザーは403を返す', async () => {
+      const req = makeGetRequest(managerUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('adminユーザーで200を返す', async () => {
+      mockListUsers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(adminUser)
+      const res = await GET(req, {})
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('USR-001: ユーザー一覧を取得できる', () => {
+    it('ユーザー一覧とmetaを返す', async () => {
+      mockListUsers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(adminUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.data).toHaveLength(1)
+      expect(body.meta).toEqual({ total: 1, page: 1, per_page: 20 })
+    })
+
+    it('レスポンスにパスワードハッシュが含まれない', async () => {
+      mockListUsers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(adminUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(body.data[0]).not.toHaveProperty('password_hash')
+      expect(body.data[0]).not.toHaveProperty('passwordHash')
+    })
+  })
+
+  describe('roleフィルタ', () => {
+    it('roleパラメータがlistUsersに渡される', async () => {
+      mockListUsers.mockResolvedValueOnce({ data: [], meta: { total: 0, page: 1, per_page: 20 } })
+
+      const req = makeGetRequest(adminUser, '?role=sales')
+      await GET(req, {})
+
+      expect(mockListUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'sales' }),
+      )
+    })
+
+    it('無効なrole値は400を返す', async () => {
+      const req = makeGetRequest(adminUser, '?role=invalid')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  describe('ページネーション', () => {
+    it('デフォルト値（page=1, per_page=20）が使われる', async () => {
+      mockListUsers.mockResolvedValueOnce(defaultListResult)
+
+      const req = makeGetRequest(adminUser)
+      await GET(req, {})
+
+      expect(mockListUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, per_page: 20 }),
+      )
+    })
+
+    it('per_pageが101の場合は400を返す', async () => {
+      const req = makeGetRequest(adminUser, '?per_page=101')
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockListUsers.mockRejectedValueOnce(new Error('DB error'))
+
+      const req = makeGetRequest(adminUser)
+      const res = await GET(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})
+
+// ─── POST /api/users ──────────────────────────────────────────────────────────
+
+describe('POST /api/users', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('認証・認可', () => {
+    it('Authorizationヘッダーがない場合は401を返す', async () => {
+      const req = new NextRequest('http://localhost/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validBody),
+      })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(401)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('salesユーザーは403を返す', async () => {
+      const req = makePostRequest(salesUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('managerユーザーは403を返す', async () => {
+      const req = makePostRequest(managerUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(403)
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  describe('USR-002: adminがユーザーを作成できる', () => {
+    it('201と作成されたユーザーを返す', async () => {
+      mockCreateUser.mockResolvedValueOnce(sampleUser)
+
+      const req = makePostRequest(adminUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(201)
+      expect(body.data).toMatchObject({ name: '山田 太郎', email: 'yamada@test.com' })
+    })
+
+    it('レスポンスにパスワードハッシュが含まれない', async () => {
+      mockCreateUser.mockResolvedValueOnce(sampleUser)
+
+      const req = makePostRequest(adminUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(body.data).not.toHaveProperty('password_hash')
+      expect(body.data).not.toHaveProperty('passwordHash')
+    })
+  })
+
+  describe('バリデーション', () => {
+    it('nameが未指定の場合は400を返す', async () => {
+      const { name: _omit, ...body } = validBody
+      const req = makePostRequest(adminUser, body)
+      const res = await POST(req, {})
+      const resBody = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(resBody.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('emailが不正な形式の場合は400を返す', async () => {
+      const req = makePostRequest(adminUser, { ...validBody, email: 'invalid' })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('passwordが7文字の場合は400を返す', async () => {
+      const req = makePostRequest(adminUser, { ...validBody, password: '1234567' })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('roleが無効な値の場合は400を返す', async () => {
+      const req = makePostRequest(adminUser, { ...validBody, role: 'superuser' })
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  describe('USR-005: メールアドレス重複', () => {
+    it('EMAIL_ALREADY_EXISTSの場合は409を返す', async () => {
+      mockCreateUser.mockRejectedValueOnce(AppError.emailAlreadyExists())
+
+      const req = makePostRequest(adminUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(409)
+      expect(body.error.code).toBe('EMAIL_ALREADY_EXISTS')
+    })
+  })
+
+  describe('エラーハンドリング', () => {
+    it('サービスが予期しないエラーを投げた場合は500を返す', async () => {
+      mockCreateUser.mockRejectedValueOnce(new Error('DB error'))
+
+      const req = makePostRequest(adminUser, validBody)
+      const res = await POST(req, {})
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error.code).toBe('INTERNAL_SERVER_ERROR')
+    })
+  })
+})

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/auth/guard'
+import { listUsersQuerySchema, createUserSchema } from '@/lib/schemas/user.schema'
+import { listUsers, createUser } from '@/lib/users/users.service'
+import { handleError } from '@/lib/errors'
+import type { AuthUser } from '@/types'
+
+async function handleGetUsers(
+  req: NextRequest,
+  _context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    const searchParams = req.nextUrl.searchParams
+
+    const rawQuery: Record<string, string | undefined> = {
+      role: searchParams.get('role') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+    }
+
+    Object.keys(rawQuery).forEach((key) => {
+      if (rawQuery[key] === undefined) {
+        delete rawQuery[key]
+      }
+    })
+
+    const query = listUsersQuerySchema.parse(rawQuery)
+    const result = await listUsers(query)
+
+    return NextResponse.json(result)
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const GET = withAuth(handleGetUsers, ['admin'])
+
+async function handlePostUser(
+  req: NextRequest,
+  _context: Record<string, unknown>,
+  _user: AuthUser,
+): Promise<NextResponse> {
+  try {
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      throw new Error('Invalid JSON')
+    }
+    const input = createUserSchema.parse(body)
+    const user = await createUser(input)
+    return NextResponse.json({ data: user }, { status: 201 })
+  } catch (err) {
+    return handleError(err)
+  }
+}
+
+export const POST = withAuth(handlePostUser, ['admin'])

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from '@/lib/auth/guard'
 import { listUsersQuerySchema, createUserSchema } from '@/lib/schemas/user.schema'
 import { listUsers, createUser } from '@/lib/users/users.service'
 import { handleError } from '@/lib/errors'
+import { AppError } from '@/lib/errors/AppError'
 import type { AuthUser } from '@/types'
 
 async function handleGetUsers(
@@ -46,7 +47,7 @@ async function handlePostUser(
     try {
       body = await req.json()
     } catch {
-      throw new Error('Invalid JSON')
+      throw AppError.validationError('リクエストボディが不正なJSON形式です')
     }
     const input = createUserSchema.parse(body)
     const user = await createUser(input)

--- a/src/lib/schemas/user.schema.ts
+++ b/src/lib/schemas/user.schema.ts
@@ -29,3 +29,25 @@ export const updateUserSchema = createUserSchema.omit({ password: true }).extend
 
 export type CreateUserInput = z.infer<typeof createUserSchema>
 export type UpdateUserInput = z.infer<typeof updateUserSchema>
+
+export const listUsersQuerySchema = z.object({
+  role: z.enum(['sales', 'manager', 'admin']).optional(),
+  page: z
+    .string()
+    .optional()
+    .transform((val) => (val !== undefined ? parseInt(val, 10) : 1))
+    .pipe(z.number().int().min(1, 'pageは1以上で指定してください')),
+  per_page: z
+    .string()
+    .optional()
+    .transform((val) => (val !== undefined ? parseInt(val, 10) : 20))
+    .pipe(
+      z
+        .number()
+        .int()
+        .min(1, 'per_pageは1以上で指定してください')
+        .max(100, 'per_pageは100以下で指定してください'),
+    ),
+})
+
+export type ListUsersQuery = z.infer<typeof listUsersQuerySchema>

--- a/src/lib/users/users.service.test.ts
+++ b/src/lib/users/users.service.test.ts
@@ -1,0 +1,402 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Prisma } from '@prisma/client'
+import { listUsers, createUser, getUser, updateUser, deleteUser } from './users.service'
+import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser } from '@/types'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    dailyReport: {
+      count: vi.fn(),
+    },
+  },
+}))
+
+// vi.hoisted で bcrypt mock 関数を作成し、restoreMocks: true で毎テスト後にリセットされた
+// 実装を beforeEach で再設定できるようにする
+const bcryptHashMock = vi.hoisted(() => vi.fn())
+
+vi.mock('bcryptjs', () => ({
+  default: {
+    hash: bcryptHashMock,
+    compare: vi.fn(),
+  },
+}))
+
+const mockCount = vi.mocked(prisma.user.count)
+const mockFindMany = vi.mocked(prisma.user.findMany)
+const mockCreate = vi.mocked(prisma.user.create)
+const mockFindUnique = vi.mocked(prisma.user.findUnique)
+const mockUpdate = vi.mocked(prisma.user.update)
+const mockDelete = vi.mocked(prisma.user.delete)
+const mockReportCount = vi.mocked(prisma.dailyReport.count)
+
+const now = new Date('2026-04-29T09:00:00.000Z')
+
+const userRecord = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+  createdAt: now,
+  updatedAt: now,
+}
+
+const userItem = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+  created_at: now.toISOString(),
+  updated_at: now.toISOString(),
+}
+
+const adminUser: AuthUser = {
+  id: '44444444-4444-4444-4444-444444444444',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+const salesUser: AuthUser = {
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const salesUser2: AuthUser = {
+  id: '22222222-2222-2222-2222-222222222222',
+  name: '鈴木 一郎',
+  email: 'suzuki@test.com',
+  role: 'sales',
+}
+
+const USER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // restoreMocks: true でリセットされるため毎テスト前に再設定する
+  bcryptHashMock.mockResolvedValue('hashed_password')
+})
+
+// ─── listUsers ───────────────────────────────────────────────────────────────
+
+describe('listUsers', () => {
+  it('ユーザー一覧を返す', async () => {
+    mockCount.mockResolvedValueOnce(1)
+    mockFindMany.mockResolvedValueOnce([userRecord] as never)
+
+    const result = await listUsers({ role: undefined, page: 1, per_page: 20 })
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]).toEqual(userItem)
+    expect(result.meta).toEqual({ total: 1, page: 1, per_page: 20 })
+  })
+
+  it('roleパラメータで絞り込みできる', async () => {
+    mockCount.mockResolvedValueOnce(1)
+    mockFindMany.mockResolvedValueOnce([userRecord] as never)
+
+    await listUsers({ role: 'sales', page: 1, per_page: 20 })
+
+    expect(mockCount).toHaveBeenCalledWith({ where: { role: 'sales' } })
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { role: 'sales' } }),
+    )
+  })
+
+  it('roleパラメータなしの場合は全件取得する', async () => {
+    mockCount.mockResolvedValueOnce(0)
+    mockFindMany.mockResolvedValueOnce([] as never)
+
+    await listUsers({ role: undefined, page: 1, per_page: 20 })
+
+    expect(mockCount).toHaveBeenCalledWith({ where: {} })
+  })
+
+  it('ページネーションのskipが正しく計算される', async () => {
+    mockCount.mockResolvedValueOnce(50)
+    mockFindMany.mockResolvedValueOnce([] as never)
+
+    await listUsers({ role: undefined, page: 3, per_page: 10 })
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 20, take: 10 }),
+    )
+  })
+
+  it('パスワードハッシュが含まれない', async () => {
+    mockCount.mockResolvedValueOnce(1)
+    mockFindMany.mockResolvedValueOnce([userRecord] as never)
+
+    const result = await listUsers({ role: undefined, page: 1, per_page: 20 })
+
+    expect(result.data[0]).not.toHaveProperty('password_hash')
+    expect(result.data[0]).not.toHaveProperty('passwordHash')
+  })
+})
+
+// ─── createUser ─────────────────────────────────────────────────────────────
+
+describe('createUser', () => {
+  const createInput = {
+    name: '山田 太郎',
+    email: 'yamada@test.com',
+    password: 'Test1234!',
+    role: 'sales' as const,
+  }
+
+  it('ユーザーを作成して返す（パスワードはハッシュ化される）', async () => {
+    mockCreate.mockResolvedValueOnce(userRecord as never)
+
+    const result = await createUser(createInput)
+
+    expect(result).toEqual(userItem)
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: '山田 太郎',
+          email: 'yamada@test.com',
+          passwordHash: 'hashed_password',
+          role: 'sales',
+        }),
+      }),
+    )
+  })
+
+  it('レスポンスにパスワードハッシュが含まれない', async () => {
+    mockCreate.mockResolvedValueOnce(userRecord as never)
+
+    const result = await createUser(createInput)
+
+    expect(result).not.toHaveProperty('password_hash')
+    expect(result).not.toHaveProperty('passwordHash')
+  })
+
+  it('メールアドレスが重複している場合はEMAIL_ALREADY_EXISTSをスローする', async () => {
+    const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+      code: 'P2002',
+      clientVersion: '5.0.0',
+    })
+    mockCreate.mockRejectedValueOnce(p2002)
+
+    await expect(createUser(createInput)).rejects.toMatchObject({ code: 'EMAIL_ALREADY_EXISTS' })
+  })
+
+  it('P2002以外のPrismaエラーはそのまま再スローされる', async () => {
+    const p2025 = new Prisma.PrismaClientKnownRequestError('Record not found', {
+      code: 'P2025',
+      clientVersion: '5.0.0',
+    })
+    mockCreate.mockRejectedValueOnce(p2025)
+
+    await expect(createUser(createInput)).rejects.toBeInstanceOf(
+      Prisma.PrismaClientKnownRequestError,
+    )
+  })
+})
+
+// ─── getUser ────────────────────────────────────────────────────────────────
+
+describe('getUser', () => {
+  it('adminは任意のユーザーを取得できる', async () => {
+    mockFindUnique.mockResolvedValueOnce(userRecord as never)
+
+    const result = await getUser(USER_ID, adminUser)
+
+    expect(result).toEqual(userItem)
+  })
+
+  it('ユーザーは自分自身のプロフィールを取得できる', async () => {
+    mockFindUnique.mockResolvedValueOnce(userRecord as never)
+
+    const result = await getUser(USER_ID, salesUser)
+
+    expect(result).toEqual(userItem)
+  })
+
+  it('non-adminが他のユーザーを取得しようとするとFORBIDDENをスローする', async () => {
+    await expect(getUser(USER_ID, salesUser2)).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(mockFindUnique).not.toHaveBeenCalled()
+  })
+
+  it('存在しないIDの場合はNOT_FOUNDをスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+
+    await expect(getUser(USER_ID, adminUser)).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('レスポンスにパスワードハッシュが含まれない', async () => {
+    mockFindUnique.mockResolvedValueOnce(userRecord as never)
+
+    const result = await getUser(USER_ID, adminUser)
+
+    expect(result).not.toHaveProperty('password_hash')
+    expect(result).not.toHaveProperty('passwordHash')
+  })
+})
+
+// ─── updateUser ─────────────────────────────────────────────────────────────
+
+describe('updateUser', () => {
+  const updateInput = {
+    name: '山田 次郎',
+    email: 'yamada2@test.com',
+    role: 'manager' as const,
+  }
+
+  it('ユーザーを更新して返す', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    const updated = { ...userRecord, name: '山田 次郎' }
+    mockUpdate.mockResolvedValueOnce(updated as never)
+
+    const result = await updateUser(USER_ID, updateInput)
+
+    expect(result.name).toBe('山田 次郎')
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: USER_ID },
+        data: expect.objectContaining({
+          name: '山田 次郎',
+          email: 'yamada2@test.com',
+          role: 'manager',
+        }),
+      }),
+    )
+  })
+
+  it('パスワードが指定された場合はハッシュ化して更新する', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    mockUpdate.mockResolvedValueOnce(userRecord as never)
+
+    await updateUser(USER_ID, { ...updateInput, password: 'NewPass123!' })
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ passwordHash: 'hashed_password' }),
+      }),
+    )
+  })
+
+  it('パスワードが省略された場合はpasswordHashを更新しない', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    mockUpdate.mockResolvedValueOnce(userRecord as never)
+
+    await updateUser(USER_ID, updateInput)
+
+    const callArg = mockUpdate.mock.calls[0][0]
+    expect(callArg.data).not.toHaveProperty('passwordHash')
+  })
+
+  it('存在しないIDの場合はNOT_FOUNDをスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+
+    await expect(updateUser(USER_ID, updateInput)).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('レースコンディション P2025 → NOT_FOUND', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    const p2025 = new Prisma.PrismaClientKnownRequestError('Record not found', {
+      code: 'P2025',
+      clientVersion: '5.0.0',
+    })
+    mockUpdate.mockRejectedValueOnce(p2025)
+
+    await expect(updateUser(USER_ID, updateInput)).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('メールアドレス重複 P2002 → EMAIL_ALREADY_EXISTS', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+      code: 'P2002',
+      clientVersion: '5.0.0',
+    })
+    mockUpdate.mockRejectedValueOnce(p2002)
+
+    await expect(updateUser(USER_ID, updateInput)).rejects.toMatchObject({
+      code: 'EMAIL_ALREADY_EXISTS',
+    })
+  })
+})
+
+// ─── deleteUser ─────────────────────────────────────────────────────────────
+
+describe('deleteUser', () => {
+  it('ユーザーを正常に削除できる', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    mockReportCount.mockResolvedValueOnce(0)
+    mockDelete.mockResolvedValueOnce({} as never)
+
+    await expect(deleteUser(USER_ID)).resolves.toBeUndefined()
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: USER_ID } })
+  })
+
+  it('存在しないIDの場合はNOT_FOUNDをスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+
+    await expect(deleteUser(USER_ID)).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(mockReportCount).not.toHaveBeenCalled()
+  })
+
+  it('日報に紐づいているユーザーはUSER_IN_USEをスローする', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    mockReportCount.mockResolvedValueOnce(3)
+
+    await expect(deleteUser(USER_ID)).rejects.toMatchObject({ code: 'USER_IN_USE' })
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it('dailyReport.countに正しいuserIdが渡される', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    mockReportCount.mockResolvedValueOnce(0)
+    mockDelete.mockResolvedValueOnce({} as never)
+
+    await deleteUser(USER_ID)
+
+    expect(mockReportCount).toHaveBeenCalledWith({ where: { userId: USER_ID } })
+  })
+
+  it('レースコンディション P2025 → NOT_FOUND', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    mockReportCount.mockResolvedValueOnce(0)
+    const p2025 = new Prisma.PrismaClientKnownRequestError('Record not found', {
+      code: 'P2025',
+      clientVersion: '5.0.0',
+    })
+    mockDelete.mockRejectedValueOnce(p2025)
+
+    await expect(deleteUser(USER_ID)).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('P2025以外のPrismaエラーはそのまま再スローされる', async () => {
+    mockFindUnique.mockResolvedValueOnce({ id: USER_ID } as never)
+    mockReportCount.mockResolvedValueOnce(0)
+    const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+      code: 'P2002',
+      clientVersion: '5.0.0',
+    })
+    mockDelete.mockRejectedValueOnce(p2002)
+
+    await expect(deleteUser(USER_ID)).rejects.toBeInstanceOf(
+      Prisma.PrismaClientKnownRequestError,
+    )
+  })
+})
+
+// ─── AppError instances ─────────────────────────────────────────────────────
+
+describe('AppError static factories', () => {
+  it('getUser: forbiddenはAppError', async () => {
+    await expect(getUser(USER_ID, salesUser2)).rejects.toBeInstanceOf(AppError)
+  })
+})

--- a/src/lib/users/users.service.ts
+++ b/src/lib/users/users.service.ts
@@ -1,0 +1,177 @@
+import bcrypt from 'bcryptjs'
+import { Prisma } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
+import { AppError } from '@/lib/errors/AppError'
+import type { AuthUser, UserRole } from '@/types'
+import type { CreateUserInput, UpdateUserInput, ListUsersQuery } from '@/lib/schemas/user.schema'
+
+export interface UserItem {
+  id: string
+  name: string
+  email: string
+  role: UserRole
+  created_at: string
+  updated_at: string
+}
+
+export interface ListUsersResult {
+  data: UserItem[]
+  meta: {
+    total: number
+    page: number
+    per_page: number
+  }
+}
+
+const userSelect = {
+  id: true,
+  name: true,
+  email: true,
+  role: true,
+  createdAt: true,
+  updatedAt: true,
+} as const
+
+function formatUser(user: {
+  id: string
+  name: string
+  email: string
+  role: string
+  createdAt: Date
+  updatedAt: Date
+}): UserItem {
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    role: user.role as UserRole,
+    created_at: user.createdAt.toISOString(),
+    updated_at: user.updatedAt.toISOString(),
+  }
+}
+
+export async function listUsers(query: ListUsersQuery): Promise<ListUsersResult> {
+  const { role, page, per_page } = query
+  const skip = (page - 1) * per_page
+  const where = role ? { role } : {}
+
+  const [total, users] = await Promise.all([
+    prisma.user.count({ where }),
+    prisma.user.findMany({
+      where,
+      skip,
+      take: per_page,
+      orderBy: { createdAt: 'asc' },
+      select: userSelect,
+    }),
+  ])
+
+  return {
+    data: users.map(formatUser),
+    meta: { total, page, per_page },
+  }
+}
+
+export async function createUser(input: CreateUserInput): Promise<UserItem> {
+  const passwordHash = await bcrypt.hash(input.password, 10)
+
+  try {
+    const user = await prisma.user.create({
+      data: {
+        name: input.name,
+        email: input.email,
+        passwordHash,
+        role: input.role,
+      },
+      select: userSelect,
+    })
+    return formatUser(user)
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      throw AppError.emailAlreadyExists()
+    }
+    throw err
+  }
+}
+
+export async function getUser(userId: string, requester: AuthUser): Promise<UserItem> {
+  // admin can access any user; non-admin users can only access their own profile
+  if (requester.role !== 'admin' && requester.id !== userId) {
+    throw AppError.forbidden()
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: userSelect,
+  })
+
+  if (!user) {
+    throw AppError.notFound('ユーザー')
+  }
+
+  return formatUser(user)
+}
+
+export async function updateUser(userId: string, input: UpdateUserInput): Promise<UserItem> {
+  const existing = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true },
+  })
+
+  if (!existing) {
+    throw AppError.notFound('ユーザー')
+  }
+
+  const data: Prisma.UserUpdateInput = {
+    name: input.name,
+    email: input.email,
+    role: input.role,
+  }
+
+  if (input.password) {
+    data.passwordHash = await bcrypt.hash(input.password, 10)
+  }
+
+  try {
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data,
+      select: userSelect,
+    })
+    return formatUser(user)
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError) {
+      if (err.code === 'P2025') throw AppError.notFound('ユーザー')
+      if (err.code === 'P2002') throw AppError.emailAlreadyExists()
+    }
+    throw err
+  }
+}
+
+export async function deleteUser(userId: string): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true },
+  })
+
+  if (!user) {
+    throw AppError.notFound('ユーザー')
+  }
+
+  const reportCount = await prisma.dailyReport.count({
+    where: { userId },
+  })
+
+  if (reportCount > 0) {
+    throw AppError.userInUse()
+  }
+
+  try {
+    await prisma.user.delete({ where: { id: userId } })
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError) {
+      if (err.code === 'P2025') throw AppError.notFound('ユーザー')
+    }
+    throw err
+  }
+}

--- a/src/lib/users/users.service.ts
+++ b/src/lib/users/users.service.ts
@@ -122,20 +122,17 @@ export async function updateUser(userId: string, input: UpdateUserInput): Promis
     throw AppError.notFound('ユーザー')
   }
 
-  const data: Prisma.UserUpdateInput = {
-    name: input.name,
-    email: input.email,
-    role: input.role,
-  }
-
-  if (input.password) {
-    data.passwordHash = await bcrypt.hash(input.password, 10)
-  }
+  const passwordHash = input.password ? await bcrypt.hash(input.password, 10) : undefined
 
   try {
     const user = await prisma.user.update({
       where: { id: userId },
-      data,
+      data: {
+        name: input.name,
+        email: input.email,
+        role: input.role,
+        ...(passwordHash ? { passwordHash } : {}),
+      },
       select: userSelect,
     })
     return formatUser(user)


### PR DESCRIPTION
## Summary

- `GET /users`: ページネーション + role フィルタ（admin のみ）
- `POST /users`: bcrypt パスワードハッシュ化 + INSERT、EMAIL_ALREADY_EXISTS 対応
- `GET /users/:id`: admin または本人のみアクセス可（service 層で制御）
- `PUT /users/:id`: パスワード省略可、P2002/P2025 レースコンディション対応
- `DELETE /users/:id`: 日報参照チェック → 409 USER_IN_USE、P2025 対応
- レスポンスから `password_hash` を除外

Closes #18

## Test plan

- [x] 認証なし → 401
- [x] sales/manager → 403（admin 専用エンドポイント）
- [x] GET /users/:id: admin → 200、本人 → 200、他人 → 403
- [x] POST: EMAIL_ALREADY_EXISTS → 409
- [x] DELETE: USER_IN_USE → 409
- [x] バリデーション（name 必須、email 形式、password 8 文字以上、role enum）
- [x] レースコンディション（P2025 → 404、P2002 → 409）
- [x] 524 テスト全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)