### PR TITLE
feat: Issue 24 SCR-005 顧客マスタ一覧 / SCR-006 顧客マスタ登録・編集

### DIFF
--- a/src/app/(protected)/customers/[id]/edit/page.tsx
+++ b/src/app/(protected)/customers/[id]/edit/page.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { CustomerForm, type CustomerFormValues } from '@/components/customers/CustomerForm'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+import type { ApiResponse } from '@/types'
+
+interface CustomerItem {
+  id: string
+  name: string
+  company: string | null
+  phone: string | null
+  email: string | null
+}
+
+export default function EditCustomerPage() {
+  const router = useRouter()
+  const params = useParams<{ id: string }>()
+  const customerId = params.id
+
+  const [defaultValues, setDefaultValues] = useState<CustomerFormValues | null>(null)
+  const [isLoadingCustomer, setIsLoadingCustomer] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchCustomer() {
+      try {
+        const res = await apiClient.get<ApiResponse<CustomerItem>>(
+          `/api/customers/${customerId}`,
+        )
+        const c = res.data
+        setDefaultValues({
+          name: c.name,
+          company: c.company ?? '',
+          phone: c.phone ?? '',
+          email: c.email ?? '',
+        })
+      } catch (err) {
+        if (err instanceof ApiClientError && err.status === 404) {
+          setLoadError('顧客が見つかりません')
+        } else {
+          setLoadError('データの取得に失敗しました')
+        }
+      } finally {
+        setIsLoadingCustomer(false)
+      }
+    }
+    void fetchCustomer()
+  }, [customerId])
+
+  async function handleSubmit(values: CustomerFormValues) {
+    setServerError(null)
+    try {
+      await apiClient.put(`/api/customers/${customerId}`, {
+        name: values.name,
+        company: values.company || undefined,
+        phone: values.phone || undefined,
+        email: values.email || undefined,
+      })
+      router.push('/customers')
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setServerError(err.message)
+      } else {
+        setServerError('保存に失敗しました。しばらく経ってから再度お試しください。')
+      }
+    }
+  }
+
+  if (isLoadingCustomer) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    )
+  }
+
+  if (loadError || !defaultValues) {
+    return (
+      <div className="mx-auto max-w-lg space-y-6">
+        <h1 className="text-2xl font-bold">顧客編集</h1>
+        <div
+          role="alert"
+          className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {loadError ?? 'データの取得に失敗しました'}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-6">
+      <h1 className="text-2xl font-bold">顧客編集</h1>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <CustomerForm
+          defaultValues={defaultValues}
+          onSubmit={handleSubmit}
+          submitLabel="保存"
+          serverError={serverError}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(protected)/customers/new/page.tsx
+++ b/src/app/(protected)/customers/new/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { CustomerForm, type CustomerFormValues } from '@/components/customers/CustomerForm'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+
+export default function NewCustomerPage() {
+  const router = useRouter()
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  async function handleSubmit(values: CustomerFormValues) {
+    setServerError(null)
+    try {
+      await apiClient.post('/api/customers', {
+        name: values.name,
+        company: values.company || undefined,
+        phone: values.phone || undefined,
+        email: values.email || undefined,
+      })
+      router.push('/customers')
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setServerError(err.message)
+      } else {
+        setServerError('保存に失敗しました。しばらく経ってから再度お試しください。')
+      }
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-6">
+      <h1 className="text-2xl font-bold">顧客登録</h1>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <CustomerForm
+          onSubmit={handleSubmit}
+          submitLabel="登録"
+          serverError={serverError}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(protected)/customers/page.tsx
+++ b/src/app/(protected)/customers/page.tsx
@@ -30,10 +30,15 @@ export default function CustomersPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  const currentPage = Number(searchParams.get('page') ?? '1')
+  const currentPage = Math.max(1, Number(searchParams.get('page')) || 1)
   const currentQ = searchParams.get('q') ?? ''
 
   const [searchInput, setSearchInput] = useState(currentQ)
+
+  // URL の q パラメータが変わったら検索ボックスも同期する（ブラウザ戻る/進む対応）
+  useEffect(() => {
+    setSearchInput(currentQ)
+  }, [currentQ])
   const [customers, setCustomers] = useState<CustomerItem[]>([])
   const [meta, setMeta] = useState({ total: 0, page: 1, per_page: PER_PAGE })
   const [isLoading, setIsLoading] = useState(true)

--- a/src/app/(protected)/customers/page.tsx
+++ b/src/app/(protected)/customers/page.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+import type { PaginatedResponse } from '@/types'
+
+interface CustomerItem {
+  id: string
+  name: string
+  company: string | null
+  phone: string | null
+  email: string | null
+}
+
+const PER_PAGE = 20
+
+export default function CustomersPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const currentPage = Number(searchParams.get('page') ?? '1')
+  const currentQ = searchParams.get('q') ?? ''
+
+  const [searchInput, setSearchInput] = useState(currentQ)
+  const [customers, setCustomers] = useState<CustomerItem[]>([])
+  const [meta, setMeta] = useState({ total: 0, page: 1, per_page: PER_PAGE })
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchCustomers = useCallback(async (q: string, page: number) => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const params = new URLSearchParams({ page: String(page), per_page: String(PER_PAGE) })
+      if (q) params.set('q', q)
+      const res = await apiClient.get<PaginatedResponse<CustomerItem>>(
+        `/api/customers?${params.toString()}`,
+      )
+      setCustomers(res.data)
+      setMeta(res.meta)
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setError(err.message)
+      } else {
+        setError('データの取得に失敗しました')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchCustomers(currentQ, currentPage)
+  }, [fetchCustomers, currentQ, currentPage])
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault()
+    const params = new URLSearchParams()
+    if (searchInput) params.set('q', searchInput)
+    params.set('page', '1')
+    router.push(`/customers?${params.toString()}`)
+  }
+
+  function handlePageChange(page: number) {
+    const params = new URLSearchParams()
+    if (currentQ) params.set('q', currentQ)
+    params.set('page', String(page))
+    router.push(`/customers?${params.toString()}`)
+  }
+
+  const totalPages = Math.ceil(meta.total / meta.per_page) || 1
+
+  return (
+    <div className="space-y-4">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">顧客マスタ</h1>
+        <Button asChild>
+          <Link href="/customers/new">+ 新規登録</Link>
+        </Button>
+      </div>
+
+      {/* 検索 */}
+      <form onSubmit={handleSearch} className="flex gap-2">
+        <Input
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="顧客名・会社名で検索"
+          className="max-w-xs"
+        />
+        <Button type="submit" variant="outline">
+          検索
+        </Button>
+      </form>
+
+      {/* エラー */}
+      {error && (
+        <div role="alert" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* テーブル */}
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>顧客名</TableHead>
+              <TableHead>会社名</TableHead>
+              <TableHead>電話番号</TableHead>
+              <TableHead className="w-20">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
+                  読み込み中...
+                </TableCell>
+              </TableRow>
+            ) : customers.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
+                  顧客が見つかりません
+                </TableCell>
+              </TableRow>
+            ) : (
+              customers.map((customer) => (
+                <TableRow key={customer.id}>
+                  <TableCell className="font-medium">{customer.name}</TableCell>
+                  <TableCell>{customer.company ?? '—'}</TableCell>
+                  <TableCell>{customer.phone ?? '—'}</TableCell>
+                  <TableCell>
+                    <Button variant="outline" size="sm" asChild>
+                      <Link href={`/customers/${customer.id}/edit`}>編集</Link>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* ページネーション */}
+      {!isLoading && (
+        <div className="flex items-center justify-center gap-4">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={currentPage <= 1}
+            onClick={() => handlePageChange(currentPage - 1)}
+          >
+            &lt; 前へ
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {currentPage} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={currentPage >= totalPages}
+            onClick={() => handlePageChange(currentPage + 1)}
+          >
+            次へ &gt;
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/customers/CustomerForm.tsx
+++ b/src/components/customers/CustomerForm.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+export const customerSchema = z.object({
+  name: z.string().min(1, '顧客名は必須です').max(100, '100文字以内で入力してください'),
+  company: z.string().max(200, '200文字以内で入力してください').optional(),
+  phone: z.string().optional(),
+  email: z
+    .string()
+    .email('メール形式で入力してください')
+    .optional()
+    .or(z.literal('')),
+})
+
+export type CustomerFormValues = z.infer<typeof customerSchema>
+
+interface CustomerFormProps {
+  defaultValues?: CustomerFormValues
+  onSubmit: (values: CustomerFormValues) => Promise<void>
+  submitLabel: string
+  serverError?: string | null
+}
+
+export function CustomerForm({
+  defaultValues = { name: '', company: '', phone: '', email: '' },
+  onSubmit,
+  submitLabel,
+  serverError,
+}: CustomerFormProps) {
+  const router = useRouter()
+
+  const form = useForm<CustomerFormValues>({
+    resolver: zodResolver(customerSchema),
+    defaultValues,
+  })
+
+  const { isSubmitting } = form.formState
+
+  async function handleSubmit(values: CustomerFormValues) {
+    await onSubmit(values)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} noValidate className="space-y-4">
+        {serverError && (
+          <div
+            role="alert"
+            className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {serverError}
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                顧客名 <span className="text-destructive">*</span>
+              </FormLabel>
+              <FormControl>
+                <Input placeholder="例: 山田 太郎" disabled={isSubmitting} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="company"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>会社名</FormLabel>
+              <FormControl>
+                <Input placeholder="例: 株式会社A" disabled={isSubmitting} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="phone"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>電話番号</FormLabel>
+              <FormControl>
+                <Input
+                  type="tel"
+                  placeholder="例: 03-1234-5678"
+                  disabled={isSubmitting}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>メールアドレス</FormLabel>
+              <FormControl>
+                <Input
+                  type="email"
+                  placeholder="例: yamada@example.com"
+                  disabled={isSubmitting}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isSubmitting}
+            onClick={() => router.push('/customers')}
+          >
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '保存中...' : submitLabel}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/customers/CustomerForm.tsx
+++ b/src/components/customers/CustomerForm.tsx
@@ -31,6 +31,7 @@ export type CustomerFormValues = z.infer<typeof customerSchema>
 interface CustomerFormProps {
   defaultValues?: CustomerFormValues
   onSubmit: (values: CustomerFormValues) => Promise<void>
+  onCancel?: () => void
   submitLabel: string
   serverError?: string | null
 }
@@ -38,6 +39,7 @@ interface CustomerFormProps {
 export function CustomerForm({
   defaultValues = { name: '', company: '', phone: '', email: '' },
   onSubmit,
+  onCancel,
   submitLabel,
   serverError,
 }: CustomerFormProps) {
@@ -50,13 +52,17 @@ export function CustomerForm({
 
   const { isSubmitting } = form.formState
 
-  async function handleSubmit(values: CustomerFormValues) {
-    await onSubmit(values)
+  function handleCancel() {
+    if (onCancel) {
+      onCancel()
+    } else {
+      router.push('/customers')
+    }
   }
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleSubmit)} noValidate className="space-y-4">
+      <form onSubmit={form.handleSubmit(onSubmit)} noValidate className="space-y-4">
         {serverError && (
           <div
             role="alert"
@@ -139,7 +145,7 @@ export function CustomerForm({
             type="button"
             variant="outline"
             disabled={isSubmitting}
-            onClick={() => router.push('/customers')}
+            onClick={handleCancel}
           >
             キャンセル
           </Button>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## Summary
- SCR-005 顧客マスタ一覧 (`/customers`): 顧客名・会社名検索、ページネーション、shadcn/ui Table
- SCR-006 顧客マスタ登録 (`/customers/new`): React Hook Form + Zod、POST /api/customers
- SCR-006 顧客マスタ編集 (`/customers/:id/edit`): 既存データ取得してフォームに反映、PUT /api/customers/:id
- 共有コンポーネント `CustomerForm` で新規・編集フォームを一元管理
- 保存・キャンセル後は `/customers` へリダイレクト

## Test plan
- [ ] `/customers` で顧客一覧が表示される
- [ ] 検索ボックスに入力して検索すると絞り込まれる
- [ ] ページネーションで前後ページに移動できる
- [ ] 「新規登録」ボタンで `/customers/new` へ遷移
- [ ] 新規登録フォームで顧客名未入力のままsubmit → バリデーションエラー
- [ ] 新規登録成功後 `/customers` へリダイレクト
- [ ] 編集ボタンで `/customers/:id/edit` へ遷移し既存データが表示される
- [ ] 編集保存後 `/customers` へリダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)