### PR TITLE
feat: SCR-003 日報作成画面を実装 (closes #22)

### DIFF
--- a/src/app/(protected)/reports/new/page.tsx
+++ b/src/app/(protected)/reports/new/page.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+import { ReportForm, type ReportFormValues } from '@/components/reports/ReportForm'
+
+// キャンセル確認ダイアログのメッセージ
+const CANCEL_CONFIRM_MESSAGE =
+  '入力内容が破棄されます。キャンセルしてもよいですか？'
+
+// 409 DUPLICATE_REPORT エラー時のユーザー向けメッセージ
+const DUPLICATE_REPORT_MESSAGE =
+  '同じ日付の日報がすでに存在します。別の日付を選択してください。'
+
+interface CreateReportRequest {
+  report_date: string
+  problem: string
+  plan: string
+  visit_records: {
+    customer_id: string
+    content: string
+    sort_order: number
+  }[]
+}
+
+export default function NewReportPage() {
+  const { user, isLoading } = useAuth()
+  const router = useRouter()
+
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  // salesロール以外はダッシュボードへリダイレクト
+  useEffect(() => {
+    if (!isLoading && user && user.role !== 'sales') {
+      router.replace('/')
+    }
+  }, [isLoading, user, router])
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <div className="text-muted-foreground">読み込み中...</div>
+      </div>
+    )
+  }
+
+  // salesロール以外はリダイレクト中なので何も表示しない
+  if (!user || user.role !== 'sales') {
+    return null
+  }
+
+  async function handleSubmit(values: ReportFormValues) {
+    setServerError(null)
+
+    const body: CreateReportRequest = {
+      report_date: values.report_date,
+      problem: values.problem,
+      plan: values.plan,
+      visit_records: values.visit_records.map((rec, index) => ({
+        customer_id: rec.customer_id,
+        content: rec.content,
+        sort_order: index,
+      })),
+    }
+
+    try {
+      await apiClient.post('/api/reports', body)
+      router.push('/')
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        if (err.code === 'DUPLICATE_REPORT') {
+          setServerError(DUPLICATE_REPORT_MESSAGE)
+        } else {
+          setServerError(err.message)
+        }
+      } else {
+        setServerError('日報の提出に失敗しました。しばらく経ってから再度お試しください。')
+      }
+    }
+  }
+
+  function handleCancel() {
+    if (window.confirm(CANCEL_CONFIRM_MESSAGE)) {
+      router.push('/')
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold">日報作成</h1>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <ReportForm
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+          serverError={serverError}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(protected)/reports/new/page.tsx
+++ b/src/app/(protected)/reports/new/page.tsx
@@ -4,26 +4,8 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 import { apiClient, ApiClientError } from '@/lib/api-client'
+import type { CreateReportInput } from '@/lib/schemas'
 import { ReportForm, type ReportFormValues } from '@/components/reports/ReportForm'
-
-// キャンセル確認ダイアログのメッセージ
-const CANCEL_CONFIRM_MESSAGE =
-  '入力内容が破棄されます。キャンセルしてもよいですか？'
-
-// 409 DUPLICATE_REPORT エラー時のユーザー向けメッセージ
-const DUPLICATE_REPORT_MESSAGE =
-  '同じ日付の日報がすでに存在します。別の日付を選択してください。'
-
-interface CreateReportRequest {
-  report_date: string
-  problem: string
-  plan: string
-  visit_records: {
-    customer_id: string
-    content: string
-    sort_order: number
-  }[]
-}
 
 export default function NewReportPage() {
   const { user, isLoading } = useAuth()
@@ -31,7 +13,6 @@ export default function NewReportPage() {
 
   const [serverError, setServerError] = useState<string | null>(null)
 
-  // salesロール以外はダッシュボードへリダイレクト
   useEffect(() => {
     if (!isLoading && user && user.role !== 'sales') {
       router.replace('/')
@@ -46,7 +27,6 @@ export default function NewReportPage() {
     )
   }
 
-  // salesロール以外はリダイレクト中なので何も表示しない
   if (!user || user.role !== 'sales') {
     return null
   }
@@ -54,14 +34,14 @@ export default function NewReportPage() {
   async function handleSubmit(values: ReportFormValues) {
     setServerError(null)
 
-    const body: CreateReportRequest = {
+    const body: CreateReportInput = {
       report_date: values.report_date,
       problem: values.problem,
       plan: values.plan,
       visit_records: values.visit_records.map((rec, index) => ({
         customer_id: rec.customer_id,
         content: rec.content,
-        sort_order: index,
+        sort_order: index + 1,
       })),
     }
 
@@ -71,7 +51,7 @@ export default function NewReportPage() {
     } catch (err) {
       if (err instanceof ApiClientError) {
         if (err.code === 'DUPLICATE_REPORT') {
-          setServerError(DUPLICATE_REPORT_MESSAGE)
+          setServerError('同じ日付の日報がすでに存在します。別の日付を選択してください。')
         } else {
           setServerError(err.message)
         }
@@ -82,7 +62,7 @@ export default function NewReportPage() {
   }
 
   function handleCancel() {
-    if (window.confirm(CANCEL_CONFIRM_MESSAGE)) {
+    if (window.confirm('入力内容が破棄されます。キャンセルしてもよいですか？')) {
       router.push('/')
     }
   }

--- a/src/components/reports/ReportForm.test.tsx
+++ b/src/components/reports/ReportForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ReportForm } from './ReportForm'
 import { apiClient } from '@/lib/api-client'
@@ -44,7 +44,7 @@ function renderReportForm(props?: { serverError?: string | null }) {
 async function waitForCustomersLoaded() {
   // 顧客セレクトがロード中でなくなるまで待つ（Select が有効化される）
   await waitFor(() => {
-    expect(apiClient.get).toHaveBeenCalledWith('/api/customers?per_page=100')
+    expect(apiClient.get).toHaveBeenCalledWith('/api/customers?per_page=100&page=1')
   })
 }
 
@@ -108,10 +108,10 @@ describe('ReportForm', () => {
   })
 
   describe('顧客一覧の読み込み', () => {
-    it('顧客一覧が /api/customers?per_page=100 から取得される', async () => {
+    it('顧客一覧が /api/customers?per_page=100&page=1 から取得される', async () => {
       renderReportForm()
       await waitFor(() => {
-        expect(apiClient.get).toHaveBeenCalledWith('/api/customers?per_page=100')
+        expect(apiClient.get).toHaveBeenCalledWith('/api/customers?per_page=100&page=1')
       })
     })
 
@@ -195,8 +195,6 @@ describe('ReportForm', () => {
       // textarea に直接 1001文字を input イベントで設定する
       const contentField = container.querySelector('textarea[name="visit_records.0.content"]') as HTMLTextAreaElement
       await user.click(contentField)
-      // fireEvent.change で直接設定
-      const { fireEvent } = await import('@testing-library/react')
       fireEvent.change(contentField, { target: { value: 'a'.repeat(1001) } })
 
       await user.click(screen.getByRole('button', { name: '提出' }))
@@ -211,7 +209,6 @@ describe('ReportForm', () => {
       const { container } = renderReportForm()
       await waitForCustomersLoaded()
 
-      const { fireEvent } = await import('@testing-library/react')
       const problemField = container.querySelector('textarea[name="problem"]') as HTMLTextAreaElement
       fireEvent.change(problemField, { target: { value: 'a'.repeat(2001) } })
 
@@ -229,7 +226,6 @@ describe('ReportForm', () => {
       const { container } = renderReportForm()
       await waitForCustomersLoaded()
 
-      const { fireEvent } = await import('@testing-library/react')
       const planField = container.querySelector('textarea[name="plan"]') as HTMLTextAreaElement
       fireEvent.change(planField, { target: { value: 'a'.repeat(2001) } })
 

--- a/src/components/reports/ReportForm.test.tsx
+++ b/src/components/reports/ReportForm.test.tsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReportForm } from './ReportForm'
+import { apiClient } from '@/lib/api-client'
+
+// apiClient をモック
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ApiClientError: class ApiClientError extends Error {
+    code: string
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+      this.name = 'ApiClientError'
+    }
+  },
+}))
+
+const mockCustomers = [
+  { id: '550e8400-e29b-41d4-a716-446655440001', name: '株式会社A', company: '株式会社A' },
+  { id: '550e8400-e29b-41d4-a716-446655440002', name: '株式会社B', company: null },
+]
+
+const mockOnSubmit = vi.fn()
+const mockOnCancel = vi.fn()
+
+function renderReportForm(props?: { serverError?: string | null }) {
+  return render(
+    <ReportForm
+      onSubmit={mockOnSubmit}
+      onCancel={mockOnCancel}
+      serverError={props?.serverError}
+    />,
+  )
+}
+
+// 顧客一覧のロード完了を待つヘルパー
+async function waitForCustomersLoaded() {
+  // 顧客セレクトがロード中でなくなるまで待つ（Select が有効化される）
+  await waitFor(() => {
+    expect(apiClient.get).toHaveBeenCalledWith('/api/customers?per_page=100')
+  })
+}
+
+beforeEach(() => {
+  vi.mocked(apiClient.get).mockResolvedValue({
+    data: mockCustomers,
+    meta: { total: 2, page: 1, per_page: 100 },
+  })
+  mockOnSubmit.mockReset()
+  mockOnCancel.mockReset()
+})
+
+describe('ReportForm', () => {
+  describe('初期表示', () => {
+    it('対象日フィールドがデフォルトで今日の日付になっている', async () => {
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      // JST基準で今日の日付を算出
+      const nowJst = new Date(Date.now() + 9 * 60 * 60 * 1000)
+      const todayJst = nowJst.toISOString().slice(0, 10)
+
+      const dateInput = screen.getByLabelText(/対象日/) as HTMLInputElement
+      expect(dateInput.value).toBe(todayJst)
+    })
+
+    it('初期状態で訪問記録が1件表示されている', async () => {
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      expect(screen.getByText('訪問先 1')).toBeInTheDocument()
+    })
+
+    it('訪問記録が1件のときは削除ボタンが表示されない', async () => {
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      expect(screen.queryByLabelText(/訪問先 1 を削除/)).not.toBeInTheDocument()
+    })
+
+    it('"訪問先を追加" ボタンが表示されている', async () => {
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      expect(screen.getByRole('button', { name: /訪問先を追加/ })).toBeInTheDocument()
+    })
+
+    it('"提出" ボタンが表示されている', async () => {
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      expect(screen.getByRole('button', { name: '提出' })).toBeInTheDocument()
+    })
+
+    it('"キャンセル" ボタンが表示されている', async () => {
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      expect(screen.getByRole('button', { name: 'キャンセル' })).toBeInTheDocument()
+    })
+  })
+
+  describe('顧客一覧の読み込み', () => {
+    it('顧客一覧が /api/customers?per_page=100 から取得される', async () => {
+      renderReportForm()
+      await waitFor(() => {
+        expect(apiClient.get).toHaveBeenCalledWith('/api/customers?per_page=100')
+      })
+    })
+
+    it('顧客一覧の取得失敗時にエラーメッセージが表示される', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('Network error'))
+      renderReportForm()
+      await waitFor(() => {
+        expect(screen.getByText('顧客一覧の取得に失敗しました')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('訪問記録の動的追加・削除', () => {
+    it('"訪問先を追加" ボタンをクリックすると訪問記録が増える', async () => {
+      const user = userEvent.setup()
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      await user.click(screen.getByRole('button', { name: /訪問先を追加/ }))
+
+      expect(screen.getByText('訪問先 1')).toBeInTheDocument()
+      expect(screen.getByText('訪問先 2')).toBeInTheDocument()
+    })
+
+    it('訪問記録が2件以上のとき削除ボタンが表示される', async () => {
+      const user = userEvent.setup()
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      await user.click(screen.getByRole('button', { name: /訪問先を追加/ }))
+
+      expect(screen.getByLabelText('訪問先 1 を削除')).toBeInTheDocument()
+      expect(screen.getByLabelText('訪問先 2 を削除')).toBeInTheDocument()
+    })
+
+    it('削除ボタンをクリックすると該当行が削除される', async () => {
+      const user = userEvent.setup()
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      await user.click(screen.getByRole('button', { name: /訪問先を追加/ }))
+      expect(screen.getByText('訪問先 2')).toBeInTheDocument()
+
+      await user.click(screen.getByLabelText('訪問先 2 を削除'))
+
+      expect(screen.queryByText('訪問先 2')).not.toBeInTheDocument()
+      expect(screen.getByText('訪問先 1')).toBeInTheDocument()
+    })
+
+    it('削除後に1件になると削除ボタンが非表示になる', async () => {
+      const user = userEvent.setup()
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      await user.click(screen.getByRole('button', { name: /訪問先を追加/ }))
+      await user.click(screen.getByLabelText('訪問先 2 を削除'))
+
+      expect(screen.queryByLabelText(/を削除/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('バリデーション', () => {
+    it('必須フィールドが空のまま提出するとエラーが表示される', async () => {
+      const user = userEvent.setup()
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      await user.click(screen.getByRole('button', { name: '提出' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('課題・相談を入力してください')).toBeInTheDocument()
+      })
+      expect(screen.getByText('明日やることを入力してください')).toBeInTheDocument()
+    })
+
+    it('訪問内容が1000文字を超えた場合はエラーが表示される', async () => {
+      const user = userEvent.setup()
+      const { container } = renderReportForm()
+      await waitForCustomersLoaded()
+
+      // textarea に直接 1001文字を input イベントで設定する
+      const contentField = container.querySelector('textarea[name="visit_records.0.content"]') as HTMLTextAreaElement
+      await user.click(contentField)
+      // fireEvent.change で直接設定
+      const { fireEvent } = await import('@testing-library/react')
+      fireEvent.change(contentField, { target: { value: 'a'.repeat(1001) } })
+
+      await user.click(screen.getByRole('button', { name: '提出' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('訪問内容は1000文字以内で入力してください')).toBeInTheDocument()
+      })
+    })
+
+    it('課題・相談が2000文字を超えた場合はエラーが表示される', async () => {
+      const user = userEvent.setup()
+      const { container } = renderReportForm()
+      await waitForCustomersLoaded()
+
+      const { fireEvent } = await import('@testing-library/react')
+      const problemField = container.querySelector('textarea[name="problem"]') as HTMLTextAreaElement
+      fireEvent.change(problemField, { target: { value: 'a'.repeat(2001) } })
+
+      await user.click(screen.getByRole('button', { name: '提出' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('課題・相談は2000文字以内で入力してください'),
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('明日やることが2000文字を超えた場合はエラーが表示される', async () => {
+      const user = userEvent.setup()
+      const { container } = renderReportForm()
+      await waitForCustomersLoaded()
+
+      const { fireEvent } = await import('@testing-library/react')
+      const planField = container.querySelector('textarea[name="plan"]') as HTMLTextAreaElement
+      fireEvent.change(planField, { target: { value: 'a'.repeat(2001) } })
+
+      await user.click(screen.getByRole('button', { name: '提出' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('明日やることは2000文字以内で入力してください'),
+        ).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('キャンセルボタン', () => {
+    it('キャンセルボタンをクリックすると onCancel が呼ばれる', async () => {
+      const user = userEvent.setup()
+      renderReportForm()
+      await waitForCustomersLoaded()
+
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+
+      expect(mockOnCancel).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('サーバーエラー表示', () => {
+    it('serverError が渡された場合はアラートとして表示される', async () => {
+      renderReportForm({ serverError: '同じ日付の日報がすでに存在します。' })
+      await waitForCustomersLoaded()
+
+      const alert = screen.getByRole('alert')
+      expect(alert).toHaveTextContent('同じ日付の日報がすでに存在します。')
+    })
+
+    it('serverError が null の場合はアラートが表示されない', async () => {
+      renderReportForm({ serverError: null })
+      await waitForCustomersLoaded()
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/reports/ReportForm.tsx
+++ b/src/components/reports/ReportForm.tsx
@@ -1,0 +1,388 @@
+'use client'
+
+import { useCallback, useEffect, useId, useState } from 'react'
+import { useFieldArray, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Plus, Trash2, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+import type { PaginatedResponse } from '@/types'
+
+// -------------------------
+// 型定義
+// -------------------------
+interface CustomerOption {
+  id: string
+  name: string
+  company: string | null
+}
+
+// -------------------------
+// フロントエンド用 Zod スキーマ
+// -------------------------
+const visitRecordFormSchema = z.object({
+  customer_id: z.string().min(1, '顧客を選択してください'),
+  content: z
+    .string()
+    .min(1, '訪問内容を入力してください')
+    .max(1000, '訪問内容は1000文字以内で入力してください'),
+})
+
+const reportFormSchema = z.object({
+  report_date: z
+    .string()
+    .min(1, '対象日を入力してください')
+    .regex(/^\d{4}-\d{2}-\d{2}$/, '対象日はYYYY-MM-DD形式で入力してください')
+    .refine((val) => {
+      const date = new Date(val)
+      return !isNaN(date.getTime()) && date.toISOString().slice(0, 10) === val
+    }, '存在しない日付は指定できません')
+    .refine((val) => {
+      // JST基準（UTC+9）で今日以前かチェック
+      const nowJst = new Date(Date.now() + 9 * 60 * 60 * 1000)
+      const todayJst = nowJst.toISOString().slice(0, 10)
+      return val <= todayJst
+    }, '未来の日付は指定できません'),
+  problem: z
+    .string()
+    .min(1, '課題・相談を入力してください')
+    .max(2000, '課題・相談は2000文字以内で入力してください'),
+  plan: z
+    .string()
+    .min(1, '明日やることを入力してください')
+    .max(2000, '明日やることは2000文字以内で入力してください'),
+  visit_records: z
+    .array(visitRecordFormSchema)
+    .min(1, '訪問記録は1件以上追加してください'),
+})
+
+export type ReportFormValues = z.infer<typeof reportFormSchema>
+
+// -------------------------
+// ユーティリティ
+// -------------------------
+function getTodayJst(): string {
+  const nowJst = new Date(Date.now() + 9 * 60 * 60 * 1000)
+  return nowJst.toISOString().slice(0, 10)
+}
+
+// -------------------------
+// Props
+// -------------------------
+interface ReportFormProps {
+  onSubmit: (values: ReportFormValues) => Promise<void>
+  onCancel: () => void
+  serverError?: string | null
+}
+
+// -------------------------
+// コンポーネント
+// -------------------------
+export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps) {
+  const formId = useId()
+
+  const [customers, setCustomers] = useState<CustomerOption[]>([])
+  const [customersLoading, setCustomersLoading] = useState(true)
+  const [customersError, setCustomersError] = useState<string | null>(null)
+
+  const form = useForm<ReportFormValues>({
+    resolver: zodResolver(reportFormSchema),
+    defaultValues: {
+      report_date: getTodayJst(),
+      problem: '',
+      plan: '',
+      visit_records: [{ customer_id: '', content: '' }],
+    },
+  })
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'visit_records',
+  })
+
+  const { isSubmitting } = form.formState
+
+  // 顧客一覧取得（全件取得）
+  const fetchAllCustomers = useCallback(async () => {
+    setCustomersLoading(true)
+    setCustomersError(null)
+    try {
+      const res = await apiClient.get<PaginatedResponse<CustomerOption>>(
+        '/api/customers?per_page=100',
+      )
+      setCustomers(res.data)
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setCustomersError(err.message)
+      } else {
+        setCustomersError('顧客一覧の取得に失敗しました')
+      }
+    } finally {
+      setCustomersLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchAllCustomers()
+  }, [fetchAllCustomers])
+
+  function handleAddVisitRecord() {
+    append({ customer_id: '', content: '' })
+  }
+
+  function handleRemoveVisitRecord(index: number) {
+    if (fields.length <= 1) return
+    remove(index)
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        id={formId}
+        onSubmit={form.handleSubmit(onSubmit)}
+        noValidate
+        className="space-y-6"
+      >
+        {/* サーバーエラー */}
+        {serverError && (
+          <div
+            role="alert"
+            className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          >
+            <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+            {serverError}
+          </div>
+        )}
+
+        {/* 対象日 */}
+        <FormField
+          control={form.control}
+          name="report_date"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                対象日 <span className="text-destructive">*</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="date"
+                  max={getTodayJst()}
+                  disabled={isSubmitting}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* 訪問記録 */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium">
+              訪問記録 <span className="text-destructive">*</span>
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleAddVisitRecord}
+              disabled={isSubmitting}
+            >
+              <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
+              訪問先を追加
+            </Button>
+          </div>
+
+          {/* visit_records 全体のバリデーションエラー */}
+          {form.formState.errors.visit_records?.root && (
+            <p className="text-sm text-destructive">
+              {form.formState.errors.visit_records.root.message}
+            </p>
+          )}
+          {/* min(1) エラーは message として出る場合もある */}
+          {typeof form.formState.errors.visit_records?.message === 'string' && (
+            <p className="text-sm text-destructive">
+              {form.formState.errors.visit_records.message}
+            </p>
+          )}
+
+          {/* 顧客一覧ロードエラー */}
+          {customersError && (
+            <div
+              role="alert"
+              className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {customersError}
+            </div>
+          )}
+
+          {fields.map((fieldItem, index) => (
+            <div
+              key={fieldItem.id}
+              className="rounded-md border bg-muted/30 p-4 space-y-3"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-muted-foreground">
+                  訪問先 {index + 1}
+                </span>
+                {/* 1行のみのときは削除ボタンを非表示 */}
+                {fields.length > 1 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                    onClick={() => handleRemoveVisitRecord(index)}
+                    disabled={isSubmitting}
+                    aria-label={`訪問先 ${index + 1} を削除`}
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    削除
+                  </Button>
+                )}
+              </div>
+
+              {/* 顧客選択 */}
+              <FormField
+                control={form.control}
+                name={`visit_records.${index}.customer_id`}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>顧客 <span className="text-destructive">*</span></FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      disabled={isSubmitting || customersLoading}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue
+                            placeholder={
+                              customersLoading ? '読み込み中...' : '顧客を選択してください'
+                            }
+                          />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {customers.map((customer) => (
+                          <SelectItem key={customer.id} value={customer.id}>
+                            {customer.name}
+                            {customer.company ? `（${customer.company}）` : ''}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 訪問内容 */}
+              <FormField
+                control={form.control}
+                name={`visit_records.${index}.content`}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      訪問内容 <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="訪問内容を入力してください（1000文字以内）"
+                        className="min-h-[100px]"
+                        maxLength={1000}
+                        disabled={isSubmitting}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* 課題・相談 */}
+        <FormField
+          control={form.control}
+          name="problem"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Problem（課題・相談） <span className="text-destructive">*</span>
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="課題・相談を入力してください（2000文字以内）"
+                  className="min-h-[120px]"
+                  maxLength={2000}
+                  disabled={isSubmitting}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* 明日やること */}
+        <FormField
+          control={form.control}
+          name="plan"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Plan（明日やること） <span className="text-destructive">*</span>
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="明日やることを入力してください（2000文字以内）"
+                  className="min-h-[120px]"
+                  maxLength={2000}
+                  disabled={isSubmitting}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* アクションボタン */}
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isSubmitting}
+            onClick={onCancel}
+          >
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '提出中...' : '提出'}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/reports/ReportForm.tsx
+++ b/src/components/reports/ReportForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useId, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -24,20 +24,15 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { apiClient, ApiClientError } from '@/lib/api-client'
+import { getTodayJst } from '@/lib/format'
 import type { PaginatedResponse } from '@/types'
 
-// -------------------------
-// 型定義
-// -------------------------
 interface CustomerOption {
   id: string
   name: string
   company: string | null
 }
 
-// -------------------------
-// フロントエンド用 Zod スキーマ
-// -------------------------
 const visitRecordFormSchema = z.object({
   customer_id: z.string().min(1, '顧客を選択してください'),
   content: z
@@ -55,12 +50,7 @@ const reportFormSchema = z.object({
       const date = new Date(val)
       return !isNaN(date.getTime()) && date.toISOString().slice(0, 10) === val
     }, '存在しない日付は指定できません')
-    .refine((val) => {
-      // JST基準（UTC+9）で今日以前かチェック
-      const nowJst = new Date(Date.now() + 9 * 60 * 60 * 1000)
-      const todayJst = nowJst.toISOString().slice(0, 10)
-      return val <= todayJst
-    }, '未来の日付は指定できません'),
+    .refine((val) => val <= getTodayJst(), '未来の日付は指定できません'),
   problem: z
     .string()
     .min(1, '課題・相談を入力してください')
@@ -76,37 +66,23 @@ const reportFormSchema = z.object({
 
 export type ReportFormValues = z.infer<typeof reportFormSchema>
 
-// -------------------------
-// ユーティリティ
-// -------------------------
-function getTodayJst(): string {
-  const nowJst = new Date(Date.now() + 9 * 60 * 60 * 1000)
-  return nowJst.toISOString().slice(0, 10)
-}
-
-// -------------------------
-// Props
-// -------------------------
 interface ReportFormProps {
   onSubmit: (values: ReportFormValues) => Promise<void>
   onCancel: () => void
   serverError?: string | null
 }
 
-// -------------------------
-// コンポーネント
-// -------------------------
 export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps) {
-  const formId = useId()
-
   const [customers, setCustomers] = useState<CustomerOption[]>([])
   const [customersLoading, setCustomersLoading] = useState(true)
   const [customersError, setCustomersError] = useState<string | null>(null)
 
+  const todayJst = getTodayJst()
+
   const form = useForm<ReportFormValues>({
     resolver: zodResolver(reportFormSchema),
     defaultValues: {
-      report_date: getTodayJst(),
+      report_date: todayJst,
       problem: '',
       plan: '',
       visit_records: [{ customer_id: '', content: '' }],
@@ -120,48 +96,46 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
 
   const { isSubmitting } = form.formState
 
-  // 顧客一覧取得（全件取得）
-  const fetchAllCustomers = useCallback(async () => {
-    setCustomersLoading(true)
-    setCustomersError(null)
-    try {
-      const res = await apiClient.get<PaginatedResponse<CustomerOption>>(
-        '/api/customers?per_page=100',
-      )
-      setCustomers(res.data)
-    } catch (err) {
-      if (err instanceof ApiClientError) {
-        setCustomersError(err.message)
-      } else {
-        setCustomersError('顧客一覧の取得に失敗しました')
-      }
-    } finally {
-      setCustomersLoading(false)
-    }
-  }, [])
-
   useEffect(() => {
+    async function fetchAllCustomers() {
+      setCustomersLoading(true)
+      setCustomersError(null)
+      try {
+        const allCustomers: CustomerOption[] = []
+        let page = 1
+        while (true) {
+          const res = await apiClient.get<PaginatedResponse<CustomerOption>>(
+            `/api/customers?per_page=100&page=${page}`,
+          )
+          allCustomers.push(...res.data)
+          if (allCustomers.length >= res.meta.total) break
+          page++
+        }
+        setCustomers(allCustomers)
+      } catch (err) {
+        if (err instanceof ApiClientError) {
+          setCustomersError(err.message)
+        } else {
+          setCustomersError('顧客一覧の取得に失敗しました')
+        }
+      } finally {
+        setCustomersLoading(false)
+      }
+    }
     void fetchAllCustomers()
-  }, [fetchAllCustomers])
+  }, [])
 
   function handleAddVisitRecord() {
     append({ customer_id: '', content: '' })
   }
 
-  function handleRemoveVisitRecord(index: number) {
-    if (fields.length <= 1) return
-    remove(index)
-  }
-
   return (
     <Form {...form}>
       <form
-        id={formId}
         onSubmit={form.handleSubmit(onSubmit)}
         noValidate
         className="space-y-6"
       >
-        {/* サーバーエラー */}
         {serverError && (
           <div
             role="alert"
@@ -172,7 +146,6 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
           </div>
         )}
 
-        {/* 対象日 */}
         <FormField
           control={form.control}
           name="report_date"
@@ -184,7 +157,7 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
               <FormControl>
                 <Input
                   type="date"
-                  max={getTodayJst()}
+                  max={todayJst}
                   disabled={isSubmitting}
                   {...field}
                 />
@@ -194,7 +167,6 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
           )}
         />
 
-        {/* 訪問記録 */}
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium">
@@ -212,20 +184,14 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
             </Button>
           </div>
 
-          {/* visit_records 全体のバリデーションエラー */}
-          {form.formState.errors.visit_records?.root && (
+          {(form.formState.errors.visit_records?.root?.message ??
+            form.formState.errors.visit_records?.message) && (
             <p className="text-sm text-destructive">
-              {form.formState.errors.visit_records.root.message}
-            </p>
-          )}
-          {/* min(1) エラーは message として出る場合もある */}
-          {typeof form.formState.errors.visit_records?.message === 'string' && (
-            <p className="text-sm text-destructive">
-              {form.formState.errors.visit_records.message}
+              {form.formState.errors.visit_records?.root?.message ??
+                form.formState.errors.visit_records?.message}
             </p>
           )}
 
-          {/* 顧客一覧ロードエラー */}
           {customersError && (
             <div
               role="alert"
@@ -244,14 +210,13 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
                 <span className="text-sm font-medium text-muted-foreground">
                   訪問先 {index + 1}
                 </span>
-                {/* 1行のみのときは削除ボタンを非表示 */}
                 {fields.length > 1 && (
                   <Button
                     type="button"
                     variant="ghost"
                     size="sm"
                     className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                    onClick={() => handleRemoveVisitRecord(index)}
+                    onClick={() => remove(index)}
                     disabled={isSubmitting}
                     aria-label={`訪問先 ${index + 1} を削除`}
                   >
@@ -261,7 +226,6 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
                 )}
               </div>
 
-              {/* 顧客選択 */}
               <FormField
                 control={form.control}
                 name={`visit_records.${index}.customer_id`}
@@ -296,7 +260,6 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
                 )}
               />
 
-              {/* 訪問内容 */}
               <FormField
                 control={form.control}
                 name={`visit_records.${index}.content`}
@@ -322,7 +285,6 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
           ))}
         </div>
 
-        {/* 課題・相談 */}
         <FormField
           control={form.control}
           name="problem"
@@ -345,7 +307,6 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
           )}
         />
 
-        {/* 明日やること */}
         <FormField
           control={form.control}
           name="plan"
@@ -368,7 +329,6 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
           )}
         />
 
-        {/* アクションボタン */}
         <div className="flex justify-end gap-3 pt-2">
           <Button
             type="button"

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }


### PR DESCRIPTION
## Summary

- `sales` ロール専用の日報作成画面 `/reports/new` を実装
- 訪問記録の動的追加・削除（1件のとき削除ボタン非表示）を実装
- 409 `DUPLICATE_REPORT` エラーをフォーム上に日本語で表示
- キャンセル時の確認ダイアログを実装
- `manager`/`admin` アクセス時はダッシュボードへリダイレクト
- shadcn/ui の `Select`・`Textarea` コンポーネントを新規追加

## 実装内容

### 新規ファイル
- `src/app/(protected)/reports/new/page.tsx` — ページコンポーネント（ロール制御・API呼び出し）
- `src/components/reports/ReportForm.tsx` — フォームコンポーネント（Zod バリデーション・動的フィールド管理）
- `src/components/reports/ReportForm.test.tsx` — コンポーネントテスト（19 ケース）
- `src/components/ui/select.tsx` — Radix UI Select をラップした shadcn/ui Select
- `src/components/ui/textarea.tsx` — shadcn/ui Textarea

### バリデーション
| フィールド | ルール |
|---|---|
| 対象日 | 必須・今日以前・YYYY-MM-DD形式 |
| 顧客（訪問記録） | 1件以上必須・各顧客の選択必須 |
| 訪問内容 | 必須・max 1000文字 |
| Problem | 必須・max 2000文字 |
| Plan | 必須・max 2000文字 |

## Test plan

- [ ] `sales` ユーザーでログインして `/reports/new` にアクセスできること
- [ ] `manager`/`admin` ユーザーでアクセスするとダッシュボードにリダイレクトされること
- [ ] 「訪問先を追加」で行が増えること
- [ ] 訪問記録が2件以上のとき各行の削除ボタンが表示されること
- [ ] 訪問記録が1件のとき削除ボタンが非表示になること
- [ ] 未来日を入力するとバリデーションエラーが表示されること
- [ ] 顧客未選択・内容空で提出するとエラーが表示されること
- [ ] 同じ日付の日報が既存の場合に「重複」エラーが表示されること
- [ ] キャンセルボタンで確認ダイアログが表示されること
- [ ] 正常提出後にダッシュボードへ遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)