### PR TITLE
feat: SCR-004 日報詳細・編集画面を実装 (closes #23)

### DIFF
--- a/src/app/(protected)/reports/[id]/page.test.tsx
+++ b/src/app/(protected)/reports/[id]/page.test.tsx
@@ -192,6 +192,17 @@ describe('ReportDetailPage', () => {
       })
     })
 
+    it('403エラー時は「この日報を閲覧する権限がありません」と表示される', async () => {
+      setupAuthAs(salesUser)
+      vi.mocked(apiClient.get).mockRejectedValue(
+        new ApiClientError('FORBIDDEN', 'Forbidden', undefined, 403),
+      )
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('この日報を閲覧する権限がありません')).toBeInTheDocument()
+      })
+    })
+
     it('エラー時は「一覧へ戻る」リンクが表示される', async () => {
       setupAuthAs(salesUser)
       vi.mocked(apiClient.get).mockRejectedValue(
@@ -399,6 +410,26 @@ describe('ReportDetailPage', () => {
       await waitFor(() => {
         expect(apiClient.delete).toHaveBeenCalledWith('/api/reports/report-id-1')
         expect(mockPush).toHaveBeenCalledWith('/')
+      })
+    })
+
+    it('削除失敗時にインラインエラーが表示される', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      vi.spyOn(window, 'confirm').mockReturnValue(true)
+      vi.mocked(apiClient.delete).mockRejectedValue(
+        new ApiClientError('SERVER_ERROR', '削除に失敗しました'),
+      )
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /削除/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /削除/ }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('削除に失敗しました')
       })
     })
 

--- a/src/app/(protected)/reports/[id]/page.test.tsx
+++ b/src/app/(protected)/reports/[id]/page.test.tsx
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ReportDetailPage from './page'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+import { useAuth } from '@/contexts/AuthContext'
+
+// Next.js のルーターをモック
+const mockPush = vi.fn()
+const mockParams = vi.fn(() => ({ id: 'report-id-1' }))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => mockParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}))
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ApiClientError: class ApiClientError extends Error {
+    code: string
+    status?: number
+    constructor(code: string, message: string, details?: unknown, status?: number) {
+      super(message)
+      this.code = code
+      this.status = status
+      this.name = 'ApiClientError'
+    }
+  },
+}))
+
+// ReportForm をモックして、テストを単純化
+vi.mock('@/components/reports/ReportForm', () => ({
+  ReportForm: ({
+    onSubmit,
+    onCancel,
+    serverError,
+    isEditMode,
+  }: {
+    onSubmit: (values: unknown) => Promise<void>
+    onCancel: () => void
+    serverError?: string | null
+    isEditMode?: boolean
+  }) => (
+    <div data-testid="report-form">
+      {serverError && <div role="alert">{serverError}</div>}
+      <span>{isEditMode ? '編集フォーム' : '新規フォーム'}</span>
+      <button
+        onClick={() =>
+          void onSubmit({
+            report_date: '2026-05-01',
+            problem: '課題テスト',
+            plan: '明日の計画',
+            visit_records: [{ customer_id: 'customer-1', content: '訪問内容' }],
+          })
+        }
+      >
+        更新
+      </button>
+      <button onClick={onCancel}>キャンセル</button>
+    </div>
+  ),
+}))
+
+const salesUser = {
+  id: 'user-sales-1',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales' as const,
+}
+
+const managerUser = {
+  id: 'user-manager-1',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager' as const,
+}
+
+const adminUser = {
+  id: 'user-admin-1',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin' as const,
+}
+
+const mockReport = {
+  id: 'report-id-1',
+  report_date: '2026-05-01',
+  problem: '課題・相談の内容',
+  plan: '明日やること',
+  user: { id: 'user-sales-1', name: '山田 太郎' },
+  visit_records: [
+    {
+      id: 'vr-1',
+      sort_order: 1,
+      customer: { id: 'customer-1', name: '株式会社A', company: '株式会社A' },
+      content: '訪問内容1',
+    },
+    {
+      id: 'vr-2',
+      sort_order: 2,
+      customer: { id: 'customer-2', name: '有限会社B', company: null },
+      content: '訪問内容2',
+    },
+  ],
+  created_at: '2026-05-01T09:00:00Z',
+  updated_at: '2026-05-01T09:00:00Z',
+}
+
+const mockComments = [
+  {
+    id: 'comment-1',
+    body: 'コメント本文',
+    user: { id: 'user-manager-1', name: '田中 部長' },
+    created_at: '2026-05-01T18:00:00Z',
+  },
+]
+
+function setupAuthAs(user: typeof salesUser | typeof managerUser | typeof adminUser) {
+  vi.mocked(useAuth).mockReturnValue({
+    user,
+    token: 'test-token',
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+  })
+}
+
+function setupApiSuccess() {
+  vi.mocked(apiClient.get).mockImplementation((path: string) => {
+    if (path.includes('/comments')) {
+      return Promise.resolve({ data: mockComments })
+    }
+    return Promise.resolve({ data: mockReport })
+  })
+}
+
+beforeEach(() => {
+  mockPush.mockReset()
+  vi.mocked(apiClient.get).mockReset()
+  vi.mocked(apiClient.put).mockReset()
+  vi.mocked(apiClient.delete).mockReset()
+})
+
+describe('ReportDetailPage', () => {
+  describe('ローディング状態', () => {
+    it('認証ロード中はローディング表示になる', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: null,
+        token: null,
+        isLoading: true,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+      render(<ReportDetailPage />)
+      expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+    })
+
+    it('データ取得中はローディング表示になる', async () => {
+      setupAuthAs(salesUser)
+      vi.mocked(apiClient.get).mockImplementation(
+        () => new Promise(() => {}), // resolve しない
+      )
+      render(<ReportDetailPage />)
+      expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+    })
+  })
+
+  describe('エラー状態', () => {
+    it('404エラー時は「日報が見つかりませんでした」と表示される', async () => {
+      setupAuthAs(salesUser)
+      vi.mocked(apiClient.get).mockRejectedValue(
+        new ApiClientError('NOT_FOUND', '日報が見つかりません', undefined, 404),
+      )
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('日報が見つかりませんでした')).toBeInTheDocument()
+      })
+    })
+
+    it('エラー時は「一覧へ戻る」リンクが表示される', async () => {
+      setupAuthAs(salesUser)
+      vi.mocked(apiClient.get).mockRejectedValue(
+        new ApiClientError('SERVER_ERROR', 'サーバーエラー', undefined, 500),
+      )
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('一覧へ戻る')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('正常表示', () => {
+    it('担当者名と対象日が表示される', async () => {
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('山田 太郎')).toBeInTheDocument()
+        expect(screen.getByText('2026/05/01')).toBeInTheDocument()
+      })
+    })
+
+    it('訪問記録がsort_order順に表示される', async () => {
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('株式会社A')).toBeInTheDocument()
+        expect(screen.getByText('有限会社B')).toBeInTheDocument()
+        expect(screen.getByText('訪問内容1')).toBeInTheDocument()
+        expect(screen.getByText('訪問内容2')).toBeInTheDocument()
+      })
+    })
+
+    it('Problem・Plan が表示される', async () => {
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('課題・相談の内容')).toBeInTheDocument()
+        expect(screen.getByText('明日やること')).toBeInTheDocument()
+      })
+    })
+
+    it('「一覧へ」リンクが表示される', async () => {
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: /一覧へ/ })).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('権限別UI制御', () => {
+    it('日報作成者（sales本人）には編集・削除ボタンが表示される', async () => {
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /削除/ })).toBeInTheDocument()
+      })
+    })
+
+    it('manager には編集・削除ボタンが表示されない', async () => {
+      setupAuthAs(managerUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /編集/ })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /削除/ })).not.toBeInTheDocument()
+      })
+    })
+
+    it('admin には編集・削除ボタンが表示されない（作成者でないため）', async () => {
+      setupAuthAs(adminUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /編集/ })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /削除/ })).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('編集モード', () => {
+    it('編集ボタンをクリックすると編集フォームが表示される', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /編集/ }))
+
+      expect(screen.getByTestId('report-form')).toBeInTheDocument()
+      expect(screen.getByText('編集フォーム')).toBeInTheDocument()
+    })
+
+    it('編集モード中は編集・削除ボタンが非表示になる', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /編集/ }))
+
+      expect(screen.queryByRole('button', { name: /編集/ })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /削除/ })).not.toBeInTheDocument()
+    })
+
+    it('更新成功後、詳細表示モードに戻る', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      vi.mocked(apiClient.put).mockResolvedValue({ data: mockReport })
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /編集/ }))
+      await user.click(screen.getByRole('button', { name: '更新' }))
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('report-form')).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument()
+      })
+    })
+
+    it('更新失敗時にエラーメッセージが表示される', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      vi.mocked(apiClient.put).mockRejectedValue(
+        new ApiClientError('SERVER_ERROR', '更新に失敗しました'),
+      )
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /編集/ }))
+      await user.click(screen.getByRole('button', { name: '更新' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('更新に失敗しました')
+      })
+    })
+
+    it('キャンセル確認で承認すると詳細表示に戻る', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      vi.spyOn(window, 'confirm').mockReturnValue(true)
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /編集/ }))
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+
+      expect(screen.queryByTestId('report-form')).not.toBeInTheDocument()
+    })
+
+    it('キャンセル確認で拒否すると編集モードのまま', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      vi.spyOn(window, 'confirm').mockReturnValue(false)
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /編集/ }))
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+
+      expect(screen.getByTestId('report-form')).toBeInTheDocument()
+    })
+  })
+
+  describe('削除機能', () => {
+    it('削除ボタンをクリックして確認ダイアログを承認すると DELETE が呼ばれて一覧に遷移する', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      vi.spyOn(window, 'confirm').mockReturnValue(true)
+      vi.mocked(apiClient.delete).mockResolvedValue(undefined)
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /削除/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /削除/ }))
+
+      await waitFor(() => {
+        expect(apiClient.delete).toHaveBeenCalledWith('/api/reports/report-id-1')
+        expect(mockPush).toHaveBeenCalledWith('/')
+      })
+    })
+
+    it('削除ボタンをクリックして確認ダイアログをキャンセルすると削除されない', async () => {
+      const user = userEvent.setup()
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      vi.spyOn(window, 'confirm').mockReturnValue(false)
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /削除/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /削除/ }))
+
+      expect(apiClient.delete).not.toHaveBeenCalled()
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('APIコール', () => {
+    it('ページロード時に GET /api/reports/:id と GET /api/reports/:id/comments が呼ばれる', async () => {
+      setupAuthAs(salesUser)
+      setupApiSuccess()
+      render(<ReportDetailPage />)
+      await waitFor(() => {
+        expect(apiClient.get).toHaveBeenCalledWith('/api/reports/report-id-1')
+        expect(apiClient.get).toHaveBeenCalledWith('/api/reports/report-id-1/comments')
+      })
+    })
+  })
+})

--- a/src/app/(protected)/reports/[id]/page.tsx
+++ b/src/app/(protected)/reports/[id]/page.tsx
@@ -43,6 +43,7 @@ export default function ReportDetailPage() {
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [isEditMode, setIsEditMode] = useState(false)
   const [updateError, setUpdateError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   const fetchReport = useCallback(async () => {
     setIsLoading(true)
@@ -62,6 +63,8 @@ export default function ReportDetailPage() {
       if (err instanceof ApiClientError) {
         if (err.status === 404) {
           setFetchError('日報が見つかりませんでした')
+        } else if (err.status === 403) {
+          setFetchError('この日報を閲覧する権限がありません')
         } else {
           setFetchError(err.message)
         }
@@ -152,14 +155,15 @@ export default function ReportDetailPage() {
 
   async function handleDelete() {
     if (!window.confirm('この日報を削除してもよいですか？この操作は取り消せません。')) return
+    setDeleteError(null)
     try {
       await apiClient.delete(`/api/reports/${reportId}`)
       router.push('/')
     } catch (err) {
       if (err instanceof ApiClientError) {
-        alert(`削除に失敗しました: ${err.message}`)
+        setDeleteError(`削除に失敗しました: ${err.message}`)
       } else {
-        alert('削除に失敗しました')
+        setDeleteError('削除に失敗しました')
       }
     }
   }
@@ -209,6 +213,17 @@ export default function ReportDetailPage() {
           )}
         </div>
       </div>
+
+      {/* 削除エラー */}
+      {deleteError && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {deleteError}
+        </div>
+      )}
 
       {/* 担当者・対象日 */}
       <div className="rounded-lg border bg-card p-4 shadow-sm">

--- a/src/app/(protected)/reports/[id]/page.tsx
+++ b/src/app/(protected)/reports/[id]/page.tsx
@@ -1,0 +1,296 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, Pencil, Trash2, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@/contexts/AuthContext'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+import { formatDate } from '@/lib/format'
+import { ReportForm, type ReportFormValues } from '@/components/reports/ReportForm'
+import { CommentSection, type Comment } from '@/components/reports/CommentSection'
+import type { ApiResponse } from '@/types'
+import type { UpdateReportInput } from '@/lib/schemas'
+
+interface VisitRecord {
+  id: string
+  sort_order: number
+  customer: { id: string; name: string; company: string | null }
+  content: string
+}
+
+interface Report {
+  id: string
+  report_date: string
+  problem: string
+  plan: string
+  user: { id: string; name: string }
+  visit_records: VisitRecord[]
+  created_at: string
+  updated_at: string
+}
+
+export default function ReportDetailPage() {
+  const params = useParams<{ id: string }>()
+  const reportId = params.id
+  const router = useRouter()
+  const { user, isLoading: authLoading } = useAuth()
+
+  const [report, setReport] = useState<Report | null>(null)
+  const [comments, setComments] = useState<Comment[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+  const [isEditMode, setIsEditMode] = useState(false)
+  const [updateError, setUpdateError] = useState<string | null>(null)
+
+  const fetchReport = useCallback(async () => {
+    setIsLoading(true)
+    setFetchError(null)
+    try {
+      const [reportRes, commentsRes] = await Promise.all([
+        apiClient.get<ApiResponse<Report>>(`/api/reports/${reportId}`),
+        apiClient.get<ApiResponse<Comment[]>>(`/api/reports/${reportId}/comments`),
+      ])
+      setReport(reportRes.data)
+      // コメントは新しい順に表示
+      const sorted = [...commentsRes.data].sort(
+        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      )
+      setComments(sorted)
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        if (err.status === 404) {
+          setFetchError('日報が見つかりませんでした')
+        } else {
+          setFetchError(err.message)
+        }
+      } else {
+        setFetchError('日報の取得に失敗しました')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [reportId])
+
+  useEffect(() => {
+    if (!authLoading) {
+      void fetchReport()
+    }
+  }, [authLoading, fetchReport])
+
+  if (authLoading || isLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <div className="text-muted-foreground">読み込み中...</div>
+      </div>
+    )
+  }
+
+  if (fetchError) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4">
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {fetchError}
+        </div>
+        <Button variant="outline" asChild>
+          <Link href="/">
+            <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
+            一覧へ戻る
+          </Link>
+        </Button>
+      </div>
+    )
+  }
+
+  if (!report || !user) {
+    return null
+  }
+
+  const isAuthor = report.user.id === user.id
+  const sortedVisitRecords = [...report.visit_records].sort(
+    (a, b) => a.sort_order - b.sort_order,
+  )
+
+  async function handleUpdate(values: ReportFormValues) {
+    setUpdateError(null)
+    const body: UpdateReportInput = {
+      problem: values.problem,
+      plan: values.plan,
+      visit_records: values.visit_records.map((rec, index) => ({
+        customer_id: rec.customer_id,
+        content: rec.content,
+        sort_order: index + 1,
+      })),
+    }
+    try {
+      const res = await apiClient.put<ApiResponse<Report>>(
+        `/api/reports/${reportId}`,
+        body,
+      )
+      setReport(res.data)
+      setIsEditMode(false)
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setUpdateError(err.message)
+      } else {
+        setUpdateError('日報の更新に失敗しました')
+      }
+    }
+  }
+
+  function handleEditCancel() {
+    if (window.confirm('編集内容が破棄されます。キャンセルしてもよいですか？')) {
+      setIsEditMode(false)
+      setUpdateError(null)
+    }
+  }
+
+  async function handleDelete() {
+    if (!window.confirm('この日報を削除してもよいですか？この操作は取り消せません。')) return
+    try {
+      await apiClient.delete(`/api/reports/${reportId}`)
+      router.push('/')
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        alert(`削除に失敗しました: ${err.message}`)
+      } else {
+        alert('削除に失敗しました')
+      }
+    }
+  }
+
+  // 編集フォームに渡すdefaultValues
+  const editDefaultValues: ReportFormValues = {
+    report_date: report.report_date,
+    problem: report.problem,
+    plan: report.plan,
+    visit_records: sortedVisitRecords.map((vr) => ({
+      customer_id: vr.customer.id,
+      content: vr.content,
+    })),
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <h1 className="text-2xl font-bold">日報詳細</h1>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/">
+              <ArrowLeft className="mr-1 h-4 w-4" aria-hidden="true" />
+              一覧へ
+            </Link>
+          </Button>
+          {isAuthor && !isEditMode && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsEditMode(true)}
+              >
+                <Pencil className="mr-1 h-4 w-4" aria-hidden="true" />
+                編集
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => void handleDelete()}
+              >
+                <Trash2 className="mr-1 h-4 w-4" aria-hidden="true" />
+                削除
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* 担当者・対象日 */}
+      <div className="rounded-lg border bg-card p-4 shadow-sm">
+        <dl className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <dt className="font-medium text-muted-foreground">担当者</dt>
+            <dd className="mt-1 font-semibold">{report.user.name}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-muted-foreground">対象日</dt>
+            <dd className="mt-1 font-semibold">{formatDate(report.report_date)}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* 編集モード */}
+      {isEditMode ? (
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <ReportForm
+            onSubmit={handleUpdate}
+            onCancel={handleEditCancel}
+            serverError={updateError}
+            defaultValues={editDefaultValues}
+            isEditMode={true}
+          />
+        </div>
+      ) : (
+        <>
+          {/* 訪問記録 */}
+          <div className="rounded-lg border bg-card p-6 shadow-sm space-y-4">
+            <h2 className="text-lg font-semibold border-b pb-2">訪問記録</h2>
+            {sortedVisitRecords.length === 0 ? (
+              <p className="text-sm text-muted-foreground">訪問記録がありません</p>
+            ) : (
+              <ol className="space-y-4">
+                {sortedVisitRecords.map((vr, index) => (
+                  <li key={vr.id} className="space-y-1">
+                    <div className="text-sm font-medium">
+                      {index + 1}.{' '}
+                      <span className="font-semibold">{vr.customer.name}</span>
+                      {vr.customer.company && (
+                        <span className="text-muted-foreground ml-1">
+                          （{vr.customer.company}）
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-muted-foreground whitespace-pre-wrap pl-4">
+                      {vr.content}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+
+          {/* Problem */}
+          <div className="rounded-lg border bg-card p-6 shadow-sm space-y-2">
+            <h2 className="text-lg font-semibold border-b pb-2">
+              Problem（課題・相談）
+            </h2>
+            <p className="text-sm whitespace-pre-wrap">{report.problem}</p>
+          </div>
+
+          {/* Plan */}
+          <div className="rounded-lg border bg-card p-6 shadow-sm space-y-2">
+            <h2 className="text-lg font-semibold border-b pb-2">
+              Plan（明日やること）
+            </h2>
+            <p className="text-sm whitespace-pre-wrap">{report.plan}</p>
+          </div>
+
+          {/* コメントセクション */}
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <CommentSection
+              reportId={reportId}
+              comments={comments}
+              currentUser={user}
+              onCommentsChange={setComments}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/CommentSection.test.tsx
+++ b/src/components/reports/CommentSection.test.tsx
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CommentSection, type Comment } from './CommentSection'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+import type { AuthUser } from '@/types'
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  ApiClientError: class ApiClientError extends Error {
+    code: string
+    status?: number
+    constructor(code: string, message: string, details?: unknown, status?: number) {
+      super(message)
+      this.code = code
+      this.status = status
+      this.name = 'ApiClientError'
+    }
+  },
+}))
+
+const reportId = '550e8400-e29b-41d4-a716-446655440000'
+
+const managerUser: AuthUser = {
+  id: 'user-manager-1',
+  name: '田中 部長',
+  email: 'tanaka@test.com',
+  role: 'manager',
+}
+
+const adminUser: AuthUser = {
+  id: 'user-admin-1',
+  name: '管理 太郎',
+  email: 'admin@test.com',
+  role: 'admin',
+}
+
+const salesUser: AuthUser = {
+  id: 'user-sales-1',
+  name: '山田 太郎',
+  email: 'yamada@test.com',
+  role: 'sales',
+}
+
+const mockComments: Comment[] = [
+  {
+    id: 'comment-1',
+    body: 'コメント本文1',
+    user: { id: 'user-manager-1', name: '田中 部長' },
+    created_at: '2026-05-01T10:00:00Z',
+  },
+  {
+    id: 'comment-2',
+    body: 'コメント本文2',
+    user: { id: 'user-manager-2', name: '佐藤 部長' },
+    created_at: '2026-05-01T09:00:00Z',
+  },
+]
+
+const mockOnCommentsChange = vi.fn()
+
+function renderCommentSection(
+  currentUser: AuthUser,
+  comments: Comment[] = [],
+) {
+  return render(
+    <CommentSection
+      reportId={reportId}
+      comments={comments}
+      currentUser={currentUser}
+      onCommentsChange={mockOnCommentsChange}
+    />,
+  )
+}
+
+beforeEach(() => {
+  mockOnCommentsChange.mockReset()
+  vi.mocked(apiClient.post).mockReset()
+  vi.mocked(apiClient.delete).mockReset()
+})
+
+describe('CommentSection', () => {
+  describe('コメント一覧表示', () => {
+    it('コメントがない場合、「コメントはまだありません」と表示される', () => {
+      renderCommentSection(managerUser, [])
+      expect(screen.getByText('コメントはまだありません')).toBeInTheDocument()
+    })
+
+    it('コメントが存在する場合、投稿者名・本文が表示される', () => {
+      renderCommentSection(managerUser, mockComments)
+      expect(screen.getByText('田中 部長')).toBeInTheDocument()
+      expect(screen.getByText('コメント本文1')).toBeInTheDocument()
+      expect(screen.getByText('佐藤 部長')).toBeInTheDocument()
+      expect(screen.getByText('コメント本文2')).toBeInTheDocument()
+    })
+  })
+
+  describe('権限別UI制御', () => {
+    it('manager はコメント投稿フォームが表示される', () => {
+      renderCommentSection(managerUser, [])
+      expect(screen.getByRole('button', { name: 'コメントを投稿' })).toBeInTheDocument()
+    })
+
+    it('admin はコメント投稿フォームが表示される', () => {
+      renderCommentSection(adminUser, [])
+      expect(screen.getByRole('button', { name: 'コメントを投稿' })).toBeInTheDocument()
+    })
+
+    it('sales はコメント投稿フォームが表示されない', () => {
+      renderCommentSection(salesUser, [])
+      expect(screen.queryByRole('button', { name: 'コメントを投稿' })).not.toBeInTheDocument()
+    })
+
+    it('manager は自分のコメントの削除ボタンが表示される', () => {
+      renderCommentSection(managerUser, mockComments)
+      expect(screen.getByLabelText('田中 部長のコメントを削除')).toBeInTheDocument()
+    })
+
+    it('manager は他人のコメントの削除ボタンが表示されない', () => {
+      renderCommentSection(managerUser, mockComments)
+      expect(screen.queryByLabelText('佐藤 部長のコメントを削除')).not.toBeInTheDocument()
+    })
+
+    it('admin は全コメントの削除ボタンが表示される', () => {
+      renderCommentSection(adminUser, mockComments)
+      expect(screen.getByLabelText('田中 部長のコメントを削除')).toBeInTheDocument()
+      expect(screen.getByLabelText('佐藤 部長のコメントを削除')).toBeInTheDocument()
+    })
+
+    it('sales はコメントの削除ボタンが表示されない', () => {
+      renderCommentSection(salesUser, mockComments)
+      expect(screen.queryByLabelText(/のコメントを削除/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('コメント投稿', () => {
+    it('コメントを入力して投稿すると POST /api/reports/:id/comments が呼ばれる', async () => {
+      const user = userEvent.setup()
+      const newComment: Comment = {
+        id: 'comment-new',
+        body: '新しいコメント',
+        user: { id: 'user-manager-1', name: '田中 部長' },
+        created_at: '2026-05-02T10:00:00Z',
+      }
+      vi.mocked(apiClient.post).mockResolvedValue({ data: newComment })
+
+      renderCommentSection(managerUser, mockComments)
+
+      const textarea = screen.getByPlaceholderText(/コメントを入力してください/)
+      await user.type(textarea, '新しいコメント')
+
+      await user.click(screen.getByRole('button', { name: 'コメントを投稿' }))
+
+      await waitFor(() => {
+        expect(apiClient.post).toHaveBeenCalledWith(
+          `/api/reports/${reportId}/comments`,
+          { body: '新しいコメント' },
+        )
+      })
+    })
+
+    it('投稿成功後、コメント一覧が更新され、フォームがリセットされる', async () => {
+      const user = userEvent.setup()
+      const newComment: Comment = {
+        id: 'comment-new',
+        body: '新しいコメント',
+        user: { id: 'user-manager-1', name: '田中 部長' },
+        created_at: '2026-05-02T10:00:00Z',
+      }
+      vi.mocked(apiClient.post).mockResolvedValue({ data: newComment })
+
+      renderCommentSection(managerUser, mockComments)
+
+      const textarea = screen.getByPlaceholderText(/コメントを入力してください/)
+      await user.type(textarea, '新しいコメント')
+      await user.click(screen.getByRole('button', { name: 'コメントを投稿' }))
+
+      await waitFor(() => {
+        expect(mockOnCommentsChange).toHaveBeenCalledWith([newComment, ...mockComments])
+      })
+
+      // フォームがリセットされている
+      expect((textarea as HTMLTextAreaElement).value).toBe('')
+    })
+
+    it('コメントが空のまま投稿するとバリデーションエラーが表示される', async () => {
+      const user = userEvent.setup()
+      renderCommentSection(managerUser, [])
+
+      await user.click(screen.getByRole('button', { name: 'コメントを投稿' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('コメントを入力してください')).toBeInTheDocument()
+      })
+    })
+
+    it('コメントが2000文字を超えるとバリデーションエラーが表示される', async () => {
+      const user = userEvent.setup()
+      renderCommentSection(managerUser, [])
+
+      const textarea = screen.getByPlaceholderText(/コメントを入力してください/) as HTMLTextAreaElement
+      fireEvent.change(textarea, { target: { value: 'a'.repeat(2001) } })
+
+      await user.click(screen.getByRole('button', { name: 'コメントを投稿' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('コメントは2000文字以内で入力してください')).toBeInTheDocument()
+      })
+    })
+
+    it('投稿失敗時にエラーメッセージが表示される', async () => {
+      const user = userEvent.setup()
+      vi.mocked(apiClient.post).mockRejectedValue(
+        new ApiClientError('SERVER_ERROR', 'サーバーエラーが発生しました'),
+      )
+
+      renderCommentSection(managerUser, [])
+
+      const textarea = screen.getByPlaceholderText(/コメントを入力してください/)
+      await user.type(textarea, 'テストコメント')
+      await user.click(screen.getByRole('button', { name: 'コメントを投稿' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('サーバーエラーが発生しました')
+      })
+    })
+  })
+
+  describe('コメント削除', () => {
+    it('削除ボタンをクリックして確認ダイアログを承認するとコメントが削除される', async () => {
+      const user = userEvent.setup()
+      vi.spyOn(window, 'confirm').mockReturnValue(true)
+      vi.mocked(apiClient.delete).mockResolvedValue(undefined)
+
+      renderCommentSection(adminUser, mockComments)
+
+      await user.click(screen.getByLabelText('田中 部長のコメントを削除'))
+
+      await waitFor(() => {
+        expect(apiClient.delete).toHaveBeenCalledWith(
+          `/api/reports/${reportId}/comments/comment-1`,
+        )
+        expect(mockOnCommentsChange).toHaveBeenCalledWith(
+          mockComments.filter((c) => c.id !== 'comment-1'),
+        )
+      })
+    })
+
+    it('削除ボタンをクリックして確認ダイアログをキャンセルすると削除されない', async () => {
+      const user = userEvent.setup()
+      vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+      renderCommentSection(adminUser, mockComments)
+
+      await user.click(screen.getByLabelText('田中 部長のコメントを削除'))
+
+      expect(apiClient.delete).not.toHaveBeenCalled()
+    })
+
+    it('削除失敗時にエラーメッセージが表示される', async () => {
+      const user = userEvent.setup()
+      vi.spyOn(window, 'confirm').mockReturnValue(true)
+      vi.mocked(apiClient.delete).mockRejectedValue(
+        new ApiClientError('SERVER_ERROR', '削除に失敗しました'),
+      )
+
+      renderCommentSection(adminUser, mockComments)
+
+      await user.click(screen.getByLabelText('田中 部長のコメントを削除'))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('削除に失敗しました')
+      })
+    })
+  })
+})

--- a/src/components/reports/CommentSection.tsx
+++ b/src/components/reports/CommentSection.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Trash2, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Textarea } from '@/components/ui/textarea'
+import { apiClient, ApiClientError } from '@/lib/api-client'
+import type { AuthUser } from '@/types'
+
+export interface Comment {
+  id: string
+  body: string
+  user: { id: string; name: string }
+  created_at: string
+}
+
+interface CommentSectionProps {
+  reportId: string
+  comments: Comment[]
+  currentUser: AuthUser
+  onCommentsChange: (comments: Comment[]) => void
+}
+
+const commentFormSchema = z.object({
+  body: z
+    .string()
+    .min(1, 'コメントを入力してください')
+    .max(2000, 'コメントは2000文字以内で入力してください'),
+})
+
+type CommentFormValues = z.infer<typeof commentFormSchema>
+
+function formatCommentDate(isoString: string): string {
+  const date = new Date(isoString)
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  const hh = String(date.getHours()).padStart(2, '0')
+  const mm = String(date.getMinutes()).padStart(2, '0')
+  return `${y}-${m}-${d} ${hh}:${mm}`
+}
+
+export function CommentSection({
+  reportId,
+  comments,
+  currentUser,
+  onCommentsChange,
+}: CommentSectionProps) {
+  const [postError, setPostError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const canPost = currentUser.role === 'manager' || currentUser.role === 'admin'
+
+  const form = useForm<CommentFormValues>({
+    resolver: zodResolver(commentFormSchema),
+    defaultValues: { body: '' },
+  })
+
+  const { isSubmitting } = form.formState
+
+  async function handlePost(values: CommentFormValues) {
+    setPostError(null)
+    try {
+      const res = await apiClient.post<{ data: Comment }>(
+        `/api/reports/${reportId}/comments`,
+        { body: values.body },
+      )
+      // 新しいコメントを先頭に追加（新しい順）
+      onCommentsChange([res.data, ...comments])
+      form.reset()
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setPostError(err.message)
+      } else {
+        setPostError('コメントの投稿に失敗しました')
+      }
+    }
+  }
+
+  async function handleDelete(commentId: string) {
+    if (!window.confirm('このコメントを削除してもよいですか？')) return
+    setDeleteError(null)
+    try {
+      await apiClient.delete(`/api/reports/${reportId}/comments/${commentId}`)
+      onCommentsChange(comments.filter((c) => c.id !== commentId))
+    } catch (err) {
+      if (err instanceof ApiClientError) {
+        setDeleteError(err.message)
+      } else {
+        setDeleteError('コメントの削除に失敗しました')
+      }
+    }
+  }
+
+  function canDeleteComment(comment: Comment): boolean {
+    if (currentUser.role === 'admin') return true
+    return comment.user.id === currentUser.id
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold border-b pb-2">コメント</h2>
+
+      {deleteError && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {deleteError}
+        </div>
+      )}
+
+      {comments.length === 0 ? (
+        <p className="text-sm text-muted-foreground">コメントはまだありません</p>
+      ) : (
+        <ul className="space-y-3" aria-label="コメント一覧">
+          {comments.map((comment) => (
+            <li
+              key={comment.id}
+              className="rounded-md border bg-muted/30 p-4 space-y-1"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium">
+                  {comment.user.name}
+                  <span className="ml-2 text-xs text-muted-foreground font-normal">
+                    {formatCommentDate(comment.created_at)}
+                  </span>
+                </span>
+                {canDeleteComment(comment) && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                    onClick={() => void handleDelete(comment.id)}
+                    aria-label={`${comment.user.name}のコメントを削除`}
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    削除
+                  </Button>
+                )}
+              </div>
+              <p className="text-sm whitespace-pre-wrap">{comment.body}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {canPost && (
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handlePost)}
+            noValidate
+            className="space-y-3 pt-2"
+          >
+            {postError && (
+              <div
+                role="alert"
+                className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+              >
+                <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+                {postError}
+              </div>
+            )}
+            <FormField
+              control={form.control}
+              name="body"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>コメントを追加（上長のみ）</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="コメントを入力してください（2000文字以内）"
+                      className="min-h-[100px]"
+                      maxLength={2000}
+                      disabled={isSubmitting}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex justify-end">
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '投稿中...' : 'コメントを投稿'}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/CommentSection.tsx
+++ b/src/components/reports/CommentSection.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/form'
 import { Textarea } from '@/components/ui/textarea'
 import { apiClient, ApiClientError } from '@/lib/api-client'
+import { formatDateTimeJst } from '@/lib/format'
 import type { AuthUser } from '@/types'
 
 export interface Comment {
@@ -41,15 +42,6 @@ const commentFormSchema = z.object({
 
 type CommentFormValues = z.infer<typeof commentFormSchema>
 
-function formatCommentDate(isoString: string): string {
-  const date = new Date(isoString)
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  const hh = String(date.getHours()).padStart(2, '0')
-  const mm = String(date.getMinutes()).padStart(2, '0')
-  return `${y}-${m}-${d} ${hh}:${mm}`
-}
 
 export function CommentSection({
   reportId,
@@ -135,7 +127,7 @@ export function CommentSection({
                 <span className="text-sm font-medium">
                   {comment.user.name}
                   <span className="ml-2 text-xs text-muted-foreground font-normal">
-                    {formatCommentDate(comment.created_at)}
+                    {formatDateTimeJst(comment.created_at)}
                   </span>
                 </span>
                 {canDeleteComment(comment) && (
@@ -179,7 +171,7 @@ export function CommentSection({
               name="body"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>コメントを追加（上長のみ）</FormLabel>
+                  <FormLabel>コメントを追加</FormLabel>
                   <FormControl>
                     <Textarea
                       placeholder="コメントを入力してください（2000文字以内）"

--- a/src/components/reports/ReportForm.tsx
+++ b/src/components/reports/ReportForm.tsx
@@ -70,9 +70,11 @@ interface ReportFormProps {
   onSubmit: (values: ReportFormValues) => Promise<void>
   onCancel: () => void
   serverError?: string | null
+  defaultValues?: Partial<ReportFormValues>
+  isEditMode?: boolean
 }
 
-export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps) {
+export function ReportForm({ onSubmit, onCancel, serverError, defaultValues, isEditMode = false }: ReportFormProps) {
   const [customers, setCustomers] = useState<CustomerOption[]>([])
   const [customersLoading, setCustomersLoading] = useState(true)
   const [customersError, setCustomersError] = useState<string | null>(null)
@@ -81,7 +83,7 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
 
   const form = useForm<ReportFormValues>({
     resolver: zodResolver(reportFormSchema),
-    defaultValues: {
+    defaultValues: defaultValues ?? {
       report_date: todayJst,
       problem: '',
       plan: '',
@@ -158,7 +160,8 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
                 <Input
                   type="date"
                   max={todayJst}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || isEditMode}
+                  readOnly={isEditMode}
                   {...field}
                 />
               </FormControl>
@@ -339,7 +342,7 @@ export function ReportForm({ onSubmit, onCancel, serverError }: ReportFormProps)
             キャンセル
           </Button>
           <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? '提出中...' : '提出'}
+            {isSubmitting ? (isEditMode ? '更新中...' : '提出中...') : (isEditMode ? '更新' : '提出')}
           </Button>
         </div>
       </form>

--- a/src/components/reports/ReportForm.tsx
+++ b/src/components/reports/ReportForm.tsx
@@ -70,7 +70,7 @@ interface ReportFormProps {
   onSubmit: (values: ReportFormValues) => Promise<void>
   onCancel: () => void
   serverError?: string | null
-  defaultValues?: Partial<ReportFormValues>
+  defaultValues?: ReportFormValues
   isEditMode?: boolean
 }
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -32,6 +32,14 @@ export function getTodayJst(): string {
 }
 
 /**
+ * UTC の ISO 文字列を JST 基準の「YYYY-MM-DD HH:MM」形式に変換
+ */
+export function formatDateTimeJst(isoString: string): string {
+  const jst = new Date(new Date(isoString).getTime() + 9 * 60 * 60 * 1000)
+  return jst.toISOString().slice(0, 16).replace('T', ' ')
+}
+
+/**
  * 直近N日の開始日と終了日を返す（YYYY-MM-DD形式）
  */
 export function getDateRangeForLastDays(days: number): { startDate: string; endDate: string } {


### PR DESCRIPTION
## Summary

- `/reports/:id` の日報詳細・編集画面を実装
- 権限別UI制御（編集・削除ボタン: 作成者本人のみ、コメント入力: manager/admin のみ）
- インライン編集モード切り替え（ReportForm を defaultValues・isEditMode 対応に拡張）
- 削除は `window.confirm` 確認ダイアログ → `DELETE /api/reports/:id` → `/` へリダイレクト
- コメント投稿・削除機能（CommentSection コンポーネントとして切り出し）
- 訪問記録は `sort_order` 昇順で番号付き表示

## Test plan

- [x] CommentSection テスト: コメント一覧表示、権限別UI制御、投稿・削除の正常系・異常系
- [x] ReportDetailPage テスト: ローディング・エラー状態、権限別ボタン表示、編集・削除フロー
- [x] `npm run lint` エラーなし
- [x] `npx tsc --noEmit` エラーなし
- [x] 全テスト (580件) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)