### PR TITLE
test: Issue 28 権限テスト（全ロール × 全操作）とセキュリティテストを実装

### DIFF
--- a/src/app/api/users/route.test.ts
+++ b/src/app/api/users/route.test.ts
@@ -111,13 +111,13 @@ describe('GET /api/users', () => {
       expect(body.error.code).toBe('FORBIDDEN')
     })
 
-    it('managerユーザーで200を返す（担当者フィルタのため許可）', async () => {
-      mockListUsers.mockResolvedValueOnce(defaultListResult)
-
+    it('managerユーザーは403を返す（admin専用）', async () => {
       const req = makeGetRequest(managerUser)
       const res = await GET(req, {})
 
-      expect(res.status).toBe(200)
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
     })
 
     it('adminユーザーで200を返す', async () => {

--- a/tests/auth/permissions.test.ts
+++ b/tests/auth/permissions.test.ts
@@ -63,20 +63,12 @@ function makeRequest(
   })
 }
 
-function reportIdContext(id: string) {
+function idContext(id: string) {
   return { params: Promise.resolve({ id }) }
 }
 
 function commentContext(id: string, commentId: string) {
   return { params: Promise.resolve({ id, commentId }) }
-}
-
-function customerIdContext(id: string) {
-  return { params: Promise.resolve({ id }) }
-}
-
-function userIdContext(id: string) {
-  return { params: Promise.resolve({ id }) }
 }
 
 describe('権限テスト（全ロール × 全操作）', () => {
@@ -267,7 +259,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', YAMADA)
-      const res = await getReport(req, reportIdContext(reportId))
+      const res = await getReport(req, idContext(reportId))
 
       expect(res.status).toBe(200)
       const body = await res.json()
@@ -282,7 +274,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', YAMADA)
-      const res = await getReport(req, reportIdContext(reportId))
+      const res = await getReport(req, idContext(reportId))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -297,7 +289,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', TANAKA)
-      const res = await getReport(req, reportIdContext(reportId))
+      const res = await getReport(req, idContext(reportId))
 
       expect(res.status).toBe(200)
     })
@@ -310,7 +302,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', ADMIN)
-      const res = await getReport(req, reportIdContext(reportId))
+      const res = await getReport(req, idContext(reportId))
 
       expect(res.status).toBe(200)
     })
@@ -334,7 +326,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'PUT', YAMADA, updateBody)
-      const res = await updateReport(req, reportIdContext(reportId))
+      const res = await updateReport(req, idContext(reportId))
 
       expect(res.status).toBe(200)
       const body = await res.json()
@@ -349,7 +341,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'PUT', YAMADA, updateBody)
-      const res = await updateReport(req, reportIdContext(reportId))
+      const res = await updateReport(req, idContext(reportId))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -364,7 +356,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'PUT', TANAKA, updateBody)
-      const res = await updateReport(req, reportIdContext(reportId))
+      const res = await updateReport(req, idContext(reportId))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -379,7 +371,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'PUT', ADMIN, updateBody)
-      const res = await updateReport(req, reportIdContext(reportId))
+      const res = await updateReport(req, idContext(reportId))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -399,7 +391,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'DELETE', YAMADA)
-      const res = await deleteReport(req, reportIdContext(reportId))
+      const res = await deleteReport(req, idContext(reportId))
 
       expect(res.status).toBe(204)
     })
@@ -412,7 +404,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'DELETE', YAMADA)
-      const res = await deleteReport(req, reportIdContext(reportId))
+      const res = await deleteReport(req, idContext(reportId))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -427,7 +419,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'DELETE', TANAKA)
-      const res = await deleteReport(req, reportIdContext(reportId))
+      const res = await deleteReport(req, idContext(reportId))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -442,7 +434,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'DELETE', ADMIN)
-      const res = await deleteReport(req, reportIdContext(reportId))
+      const res = await deleteReport(req, idContext(reportId))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -463,7 +455,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       await createTestComment({ reportId, commenterId: TANAKA.id, body: '良い日報です' })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}/comments`, 'GET', YAMADA)
-      const res = await listComments(req, reportIdContext(reportId))
+      const res = await listComments(req, idContext(reportId))
 
       expect(res.status).toBe(200)
       const body = await res.json()
@@ -479,7 +471,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       await createTestComment({ reportId, commenterId: TANAKA.id, body: '良い日報です' })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}/comments`, 'GET', TANAKA)
-      const res = await listComments(req, reportIdContext(reportId))
+      const res = await listComments(req, idContext(reportId))
 
       expect(res.status).toBe(200)
     })
@@ -493,7 +485,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       await createTestComment({ reportId, commenterId: TANAKA.id, body: '良い日報です' })
 
       const req = makeRequest(`${REPORTS_BASE}/${reportId}/comments`, 'GET', ADMIN)
-      const res = await listComments(req, reportIdContext(reportId))
+      const res = await listComments(req, idContext(reportId))
 
       expect(res.status).toBe(200)
     })
@@ -516,7 +508,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
         YAMADA,
         { body: 'コメントしたい' },
       )
-      const res = await createComment(req, reportIdContext(reportId))
+      const res = await createComment(req, idContext(reportId))
 
       expect(res.status).toBe(403)
       const resBody = await res.json()
@@ -536,7 +528,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
         TANAKA,
         { body: '管理職コメント' },
       )
-      const res = await createComment(req, reportIdContext(reportId))
+      const res = await createComment(req, idContext(reportId))
 
       expect(res.status).toBe(201)
       const resBody = await res.json()
@@ -556,7 +548,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
         ADMIN,
         { body: '管理者コメント' },
       )
-      const res = await createComment(req, reportIdContext(reportId))
+      const res = await createComment(req, idContext(reportId))
 
       expect(res.status).toBe(201)
       const resBody = await res.json()
@@ -566,9 +558,13 @@ describe('権限テスト（全ロール × 全操作）', () => {
 
   // ─── AUTH-P13: コメント削除（自分） ───────────────────────────────────────────
   // sales: ✕, manager: ○, admin: ○
+  // 注意: sales はコメントを作成できないロールのため、「自分のコメント」という概念自体が存在しない。
+  //       ここでは sales が他者（manager）のコメントを削除しようとした場合の 403 を検証する。
 
   describe('AUTH-P13: コメント削除（自分のコメント）', () => {
-    it('sales は自分以外の投稿したコメントを削除できない（403）', async () => {
+    // sales はコメント投稿権限がないため自分のコメントは存在しない。
+    // 他者（manager）のコメントを削除しようとした場合も 403 になることを検証する。
+    it('sales は他ロールが投稿したコメントを削除できない（403）', async () => {
       const reportId = await createTestReport({
         userId: YAMADA.id,
         reportDate: '2026-05-01',
@@ -772,7 +768,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'PUT', YAMADA, {
         name: '佐藤 健（sales更新）',
       })
-      const res = await updateCustomer(req, customerIdContext(CUST01.id))
+      const res = await updateCustomer(req, idContext(CUST01.id))
 
       expect(res.status).toBe(200)
     })
@@ -781,7 +777,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'PUT', TANAKA, {
         name: '佐藤 健（manager更新）',
       })
-      const res = await updateCustomer(req, customerIdContext(CUST01.id))
+      const res = await updateCustomer(req, idContext(CUST01.id))
 
       expect(res.status).toBe(200)
     })
@@ -790,7 +786,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
       const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'PUT', ADMIN, {
         name: '佐藤 健（admin更新）',
       })
-      const res = await updateCustomer(req, customerIdContext(CUST01.id))
+      const res = await updateCustomer(req, idContext(CUST01.id))
 
       expect(res.status).toBe(200)
     })
@@ -802,7 +798,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
   describe('AUTH-P23: 顧客削除', () => {
     it('sales は顧客を削除できない（403）', async () => {
       const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'DELETE', YAMADA)
-      const res = await deleteCustomer(req, customerIdContext(CUST01.id))
+      const res = await deleteCustomer(req, idContext(CUST01.id))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -811,7 +807,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
 
     it('manager は顧客を削除できない（403）', async () => {
       const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'DELETE', TANAKA)
-      const res = await deleteCustomer(req, customerIdContext(CUST01.id))
+      const res = await deleteCustomer(req, idContext(CUST01.id))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -820,7 +816,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
 
     it('admin は顧客を削除できる（204）', async () => {
       const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'DELETE', ADMIN)
-      const res = await deleteCustomer(req, customerIdContext(CUST01.id))
+      const res = await deleteCustomer(req, idContext(CUST01.id))
 
       expect(res.status).toBe(204)
     })
@@ -902,7 +898,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
         email: SUZUKI.email,
         role: 'sales',
       })
-      const res = await updateUser(req, userIdContext(SUZUKI.id))
+      const res = await updateUser(req, idContext(SUZUKI.id))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -915,7 +911,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
         email: YAMADA.email,
         role: 'sales',
       })
-      const res = await updateUser(req, userIdContext(YAMADA.id))
+      const res = await updateUser(req, idContext(YAMADA.id))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -928,7 +924,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
         email: YAMADA.email,
         role: 'sales',
       })
-      const res = await updateUser(req, userIdContext(YAMADA.id))
+      const res = await updateUser(req, idContext(YAMADA.id))
 
       expect(res.status).toBe(200)
       const body = await res.json()
@@ -937,7 +933,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
 
     it('sales はユーザーを削除できない（403）', async () => {
       const req = makeRequest(`${USERS_BASE}/${SUZUKI.id}`, 'DELETE', YAMADA)
-      const res = await deleteUser(req, userIdContext(SUZUKI.id))
+      const res = await deleteUser(req, idContext(SUZUKI.id))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -946,7 +942,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
 
     it('manager はユーザーを削除できない（403）', async () => {
       const req = makeRequest(`${USERS_BASE}/${YAMADA.id}`, 'DELETE', TANAKA)
-      const res = await deleteUser(req, userIdContext(YAMADA.id))
+      const res = await deleteUser(req, idContext(YAMADA.id))
 
       expect(res.status).toBe(403)
       const body = await res.json()
@@ -956,7 +952,7 @@ describe('権限テスト（全ロール × 全操作）', () => {
     it('admin はユーザーを削除できる（204）', async () => {
       // SUZUKI は日報なしなので削除可能
       const req = makeRequest(`${USERS_BASE}/${SUZUKI.id}`, 'DELETE', ADMIN)
-      const res = await deleteUser(req, userIdContext(SUZUKI.id))
+      const res = await deleteUser(req, idContext(SUZUKI.id))
 
       expect(res.status).toBe(204)
     })

--- a/tests/auth/permissions.test.ts
+++ b/tests/auth/permissions.test.ts
@@ -1,0 +1,964 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET as listReports, POST as createReport } from '@/app/api/reports/route'
+import {
+  GET as getReport,
+  PUT as updateReport,
+  DELETE as deleteReport,
+} from '@/app/api/reports/[id]/route'
+import {
+  GET as listComments,
+  POST as createComment,
+} from '@/app/api/reports/[id]/comments/route'
+import { DELETE as deleteComment } from '@/app/api/reports/[id]/comments/[commentId]/route'
+import { GET as listCustomers, POST as createCustomer } from '@/app/api/customers/route'
+import {
+  PUT as updateCustomer,
+  DELETE as deleteCustomer,
+} from '@/app/api/customers/[id]/route'
+import { GET as listUsers, POST as createUser } from '@/app/api/users/route'
+import {
+  PUT as updateUser,
+  DELETE as deleteUser,
+} from '@/app/api/users/[id]/route'
+import {
+  clearDatabase,
+  seedTestUsers,
+  seedTestCustomers,
+  createTestReport,
+  createTestComment,
+  prisma,
+  TEST_USERS,
+  TEST_CUSTOMERS,
+  PASSWORD_HASH,
+} from '../helpers/db'
+import { makeToken } from '../helpers/auth'
+import type { AuthUser } from '@/types'
+
+const YAMADA = TEST_USERS.yamada  // sales (USER-01)
+const SUZUKI = TEST_USERS.suzuki  // sales (USER-02)
+const TANAKA = TEST_USERS.tanaka  // manager (USER-03)
+const ADMIN = TEST_USERS.admin    // admin (USER-04)
+
+const CUST01 = TEST_CUSTOMERS.cust01
+
+const REPORTS_BASE = 'http://localhost/api/reports'
+const CUSTOMERS_BASE = 'http://localhost/api/customers'
+const USERS_BASE = 'http://localhost/api/users'
+
+function makeRequest(
+  url: string,
+  method: string,
+  user: AuthUser,
+  body?: unknown,
+): NextRequest {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${makeToken(user)}`,
+  }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+function reportIdContext(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+function commentContext(id: string, commentId: string) {
+  return { params: Promise.resolve({ id, commentId }) }
+}
+
+function customerIdContext(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+function userIdContext(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+describe('権限テスト（全ロール × 全操作）', () => {
+  beforeEach(async () => {
+    await clearDatabase()
+    await seedTestUsers()
+    await seedTestCustomers()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  // ─── AUTH-P01: 日報一覧（全員分）閲覧 ────────────────────────────────────────
+  // sales: ✕（自分の分しか見えない）, manager: ○, admin: ○
+
+  describe('AUTH-P01: 日報一覧（全員分）閲覧', () => {
+    it('manager は全ユーザーの日報を閲覧できる', async () => {
+      await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '山田訪問', sortOrder: 1 }],
+      })
+      await createTestReport({
+        userId: SUZUKI.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '鈴木訪問', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(REPORTS_BASE, 'GET', TANAKA)
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data).toHaveLength(2)
+    })
+
+    it('admin は全ユーザーの日報を閲覧できる', async () => {
+      await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '山田訪問', sortOrder: 1 }],
+      })
+      await createTestReport({
+        userId: SUZUKI.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '鈴木訪問', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(REPORTS_BASE, 'GET', ADMIN)
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data).toHaveLength(2)
+    })
+
+    it('sales は自分の日報しか閲覧できない（全員分は見えない）', async () => {
+      await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '山田訪問', sortOrder: 1 }],
+      })
+      await createTestReport({
+        userId: SUZUKI.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '鈴木訪問', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(REPORTS_BASE, 'GET', YAMADA)
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // sales は自分の分しか返らない
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].user.id).toBe(YAMADA.id)
+    })
+  })
+
+  // ─── AUTH-P02: 日報一覧（自分分）閲覧 ────────────────────────────────────────
+  // sales本人: ○, sales他人: ✕, manager: ○, admin: ○
+
+  describe('AUTH-P02: 日報一覧（自分分）閲覧', () => {
+    it('sales は自分の日報一覧を閲覧できる', async () => {
+      await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '山田訪問', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}?user_id=${YAMADA.id}`, 'GET', YAMADA)
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].user.id).toBe(YAMADA.id)
+    })
+
+    it('sales が他人の user_id でフィルタしても自分の分しか返らない', async () => {
+      await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '山田訪問', sortOrder: 1 }],
+      })
+      await createTestReport({
+        userId: SUZUKI.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '鈴木訪問', sortOrder: 1 }],
+      })
+
+      // YAMADA が SUZUKI の日報を user_id フィルタで取得しようとする
+      const req = makeRequest(`${REPORTS_BASE}?user_id=${SUZUKI.id}`, 'GET', YAMADA)
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // sales は他人の user_id フィルタ結果を得られない（空 or 自分の分だけ）
+      expect(body.data.every((r: { user: { id: string } }) => r.user.id === YAMADA.id)).toBe(true)
+    })
+
+    it('manager は特定 user_id でフィルタして他ユーザーの日報を閲覧できる', async () => {
+      await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '山田訪問', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}?user_id=${YAMADA.id}`, 'GET', TANAKA)
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data).toHaveLength(1)
+      expect(body.data[0].user.id).toBe(YAMADA.id)
+    })
+  })
+
+  // ─── AUTH-P03: 日報作成 ────────────────────────────────────────────────────────
+  // sales本人: ○, manager: ✕, admin: ✕
+
+  describe('AUTH-P03: 日報作成', () => {
+    const reportBody = {
+      report_date: '2026-05-01',
+      problem: 'テスト課題',
+      plan: 'テスト計画',
+      visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+    }
+
+    it('sales は日報を作成できる（201）', async () => {
+      const req = makeRequest(REPORTS_BASE, 'POST', YAMADA, reportBody)
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.user.id).toBe(YAMADA.id)
+    })
+
+    it('manager は日報を作成できない（403）', async () => {
+      const req = makeRequest(REPORTS_BASE, 'POST', TANAKA, reportBody)
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin は日報を作成できない（403）', async () => {
+      const req = makeRequest(REPORTS_BASE, 'POST', ADMIN, reportBody)
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ─── AUTH-P04: 日報詳細閲覧 ──────────────────────────────────────────────────
+  // sales本人: ○, sales他人: ✕, manager: ○, admin: ○
+
+  describe('AUTH-P04: 日報詳細閲覧', () => {
+    it('sales は自分の日報詳細を閲覧できる（200）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', YAMADA)
+      const res = await getReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.id).toBe(reportId)
+    })
+
+    it('sales は他人の日報詳細を閲覧できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: SUZUKI.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', YAMADA)
+      const res = await getReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager は任意のユーザーの日報詳細を閲覧できる（200）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', TANAKA)
+      const res = await getReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(200)
+    })
+
+    it('admin は任意のユーザーの日報詳細を閲覧できる（200）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', ADMIN)
+      const res = await getReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  // ─── AUTH-P05: 日報編集 ────────────────────────────────────────────────────────
+  // sales本人: ○, sales他人: ✕, manager: ✕, admin: ✕
+
+  describe('AUTH-P05: 日報編集', () => {
+    const updateBody = {
+      problem: '更新後課題',
+      plan: '更新後計画',
+      visit_records: [{ customer_id: CUST01.id, content: '更新後訪問内容', sort_order: 1 }],
+    }
+
+    it('sales は自分の日報を編集できる（200）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '元の訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'PUT', YAMADA, updateBody)
+      const res = await updateReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.problem).toBe('更新後課題')
+    })
+
+    it('sales は他人の日報を編集できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: SUZUKI.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '元の訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'PUT', YAMADA, updateBody)
+      const res = await updateReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager は日報を編集できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '元の訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'PUT', TANAKA, updateBody)
+      const res = await updateReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin は日報を編集できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '元の訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'PUT', ADMIN, updateBody)
+      const res = await updateReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ─── AUTH-P06: 日報削除 ────────────────────────────────────────────────────────
+  // sales本人: ○, sales他人: ✕, manager: ✕, admin: ✕
+
+  describe('AUTH-P06: 日報削除', () => {
+    it('sales は自分の日報を削除できる（204）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'DELETE', YAMADA)
+      const res = await deleteReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(204)
+    })
+
+    it('sales は他人の日報を削除できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: SUZUKI.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'DELETE', YAMADA)
+      const res = await deleteReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager は日報を削除できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'DELETE', TANAKA)
+      const res = await deleteReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin は日報を削除できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'DELETE', ADMIN)
+      const res = await deleteReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ─── AUTH-P11: コメント閲覧 ───────────────────────────────────────────────────
+  // sales: ○, manager: ○, admin: ○
+
+  describe('AUTH-P11: コメント閲覧', () => {
+    it('sales は日報のコメントを閲覧できる（200）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      await createTestComment({ reportId, commenterId: TANAKA.id, body: '良い日報です' })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}/comments`, 'GET', YAMADA)
+      const res = await listComments(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data).toHaveLength(1)
+    })
+
+    it('manager は日報のコメントを閲覧できる（200）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      await createTestComment({ reportId, commenterId: TANAKA.id, body: '良い日報です' })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}/comments`, 'GET', TANAKA)
+      const res = await listComments(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(200)
+    })
+
+    it('admin は日報のコメントを閲覧できる（200）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      await createTestComment({ reportId, commenterId: TANAKA.id, body: '良い日報です' })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}/comments`, 'GET', ADMIN)
+      const res = await listComments(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  // ─── AUTH-P12: コメント投稿 ───────────────────────────────────────────────────
+  // sales: ✕, manager: ○, admin: ○
+
+  describe('AUTH-P12: コメント投稿', () => {
+    it('sales はコメントを投稿できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments`,
+        'POST',
+        YAMADA,
+        { body: 'コメントしたい' },
+      )
+      const res = await createComment(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const resBody = await res.json()
+      expect(resBody.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager はコメントを投稿できる（201）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments`,
+        'POST',
+        TANAKA,
+        { body: '管理職コメント' },
+      )
+      const res = await createComment(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(201)
+      const resBody = await res.json()
+      expect(resBody.data.commenter.id).toBe(TANAKA.id)
+    })
+
+    it('admin はコメントを投稿できる（201）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments`,
+        'POST',
+        ADMIN,
+        { body: '管理者コメント' },
+      )
+      const res = await createComment(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(201)
+      const resBody = await res.json()
+      expect(resBody.data.commenter.id).toBe(ADMIN.id)
+    })
+  })
+
+  // ─── AUTH-P13: コメント削除（自分） ───────────────────────────────────────────
+  // sales: ✕, manager: ○, admin: ○
+
+  describe('AUTH-P13: コメント削除（自分のコメント）', () => {
+    it('sales は自分以外の投稿したコメントを削除できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      const commentId = await createTestComment({ reportId, commenterId: TANAKA.id })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments/${commentId}`,
+        'DELETE',
+        YAMADA,
+      )
+      const res = await deleteComment(req, commentContext(reportId, commentId))
+
+      expect(res.status).toBe(403)
+      const resBody = await res.json()
+      expect(resBody.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager は自分のコメントを削除できる（204）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      const commentId = await createTestComment({ reportId, commenterId: TANAKA.id })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments/${commentId}`,
+        'DELETE',
+        TANAKA,
+      )
+      const res = await deleteComment(req, commentContext(reportId, commentId))
+
+      expect(res.status).toBe(204)
+    })
+
+    it('admin は自分のコメントを削除できる（204）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      const commentId = await createTestComment({ reportId, commenterId: ADMIN.id })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments/${commentId}`,
+        'DELETE',
+        ADMIN,
+      )
+      const res = await deleteComment(req, commentContext(reportId, commentId))
+
+      expect(res.status).toBe(204)
+    })
+  })
+
+  // ─── AUTH-P14: コメント削除（他人） ───────────────────────────────────────────
+  // sales: ✕, manager: ✕, admin: ○
+
+  describe('AUTH-P14: コメント削除（他人のコメント）', () => {
+    it('sales は他人のコメントを削除できない（403）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      const commentId = await createTestComment({ reportId, commenterId: TANAKA.id })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments/${commentId}`,
+        'DELETE',
+        YAMADA,
+      )
+      const res = await deleteComment(req, commentContext(reportId, commentId))
+
+      expect(res.status).toBe(403)
+      const resBody = await res.json()
+      expect(resBody.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager は他の manager のコメントを削除できない（403）', async () => {
+      const otherManagerId = '00000000-0000-0000-0000-000000000088'
+      await prisma.user.create({
+        data: {
+          id: otherManagerId,
+          name: '別の部長',
+          email: 'other-manager2@test.com',
+          passwordHash: PASSWORD_HASH,
+          role: 'manager',
+        },
+      })
+      const otherManager: AuthUser = {
+        id: otherManagerId,
+        name: '別の部長',
+        email: 'other-manager2@test.com',
+        role: 'manager',
+      }
+
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      // TANAKA のコメントを otherManager が削除しようとする
+      const commentId = await createTestComment({ reportId, commenterId: TANAKA.id })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments/${commentId}`,
+        'DELETE',
+        otherManager,
+      )
+      const res = await deleteComment(req, commentContext(reportId, commentId))
+
+      expect(res.status).toBe(403)
+      const resBody = await res.json()
+      expect(resBody.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin は他人のコメントを削除できる（204）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+      const commentId = await createTestComment({ reportId, commenterId: TANAKA.id })
+
+      const req = makeRequest(
+        `${REPORTS_BASE}/${reportId}/comments/${commentId}`,
+        'DELETE',
+        ADMIN,
+      )
+      const res = await deleteComment(req, commentContext(reportId, commentId))
+
+      expect(res.status).toBe(204)
+    })
+  })
+
+  // ─── AUTH-P21: 顧客一覧閲覧 ──────────────────────────────────────────────────
+  // sales: ○, manager: ○, admin: ○
+
+  describe('AUTH-P21: 顧客一覧閲覧', () => {
+    it('sales は顧客一覧を閲覧できる（200）', async () => {
+      const req = makeRequest(CUSTOMERS_BASE, 'GET', YAMADA)
+      const res = await listCustomers(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('manager は顧客一覧を閲覧できる（200）', async () => {
+      const req = makeRequest(CUSTOMERS_BASE, 'GET', TANAKA)
+      const res = await listCustomers(req, {})
+
+      expect(res.status).toBe(200)
+    })
+
+    it('admin は顧客一覧を閲覧できる（200）', async () => {
+      const req = makeRequest(CUSTOMERS_BASE, 'GET', ADMIN)
+      const res = await listCustomers(req, {})
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  // ─── AUTH-P22: 顧客登録・編集 ────────────────────────────────────────────────
+  // sales: ○, manager: ○, admin: ○
+
+  describe('AUTH-P22: 顧客登録・編集', () => {
+    it('sales は顧客を登録できる（201）', async () => {
+      const req = makeRequest(CUSTOMERS_BASE, 'POST', YAMADA, {
+        name: '新規顧客（sales）',
+        company: '株式会社テスト',
+      })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(201)
+    })
+
+    it('manager は顧客を登録できる（201）', async () => {
+      const req = makeRequest(CUSTOMERS_BASE, 'POST', TANAKA, {
+        name: '新規顧客（manager）',
+        company: '株式会社テスト',
+      })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(201)
+    })
+
+    it('admin は顧客を登録できる（201）', async () => {
+      const req = makeRequest(CUSTOMERS_BASE, 'POST', ADMIN, {
+        name: '新規顧客（admin）',
+        company: '株式会社テスト',
+      })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(201)
+    })
+
+    it('sales は顧客を編集できる（200）', async () => {
+      const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'PUT', YAMADA, {
+        name: '佐藤 健（sales更新）',
+      })
+      const res = await updateCustomer(req, customerIdContext(CUST01.id))
+
+      expect(res.status).toBe(200)
+    })
+
+    it('manager は顧客を編集できる（200）', async () => {
+      const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'PUT', TANAKA, {
+        name: '佐藤 健（manager更新）',
+      })
+      const res = await updateCustomer(req, customerIdContext(CUST01.id))
+
+      expect(res.status).toBe(200)
+    })
+
+    it('admin は顧客を編集できる（200）', async () => {
+      const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'PUT', ADMIN, {
+        name: '佐藤 健（admin更新）',
+      })
+      const res = await updateCustomer(req, customerIdContext(CUST01.id))
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  // ─── AUTH-P23: 顧客削除 ────────────────────────────────────────────────────────
+  // sales: ✕, manager: ✕, admin: ○
+
+  describe('AUTH-P23: 顧客削除', () => {
+    it('sales は顧客を削除できない（403）', async () => {
+      const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'DELETE', YAMADA)
+      const res = await deleteCustomer(req, customerIdContext(CUST01.id))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager は顧客を削除できない（403）', async () => {
+      const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'DELETE', TANAKA)
+      const res = await deleteCustomer(req, customerIdContext(CUST01.id))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin は顧客を削除できる（204）', async () => {
+      const req = makeRequest(`${CUSTOMERS_BASE}/${CUST01.id}`, 'DELETE', ADMIN)
+      const res = await deleteCustomer(req, customerIdContext(CUST01.id))
+
+      expect(res.status).toBe(204)
+    })
+  })
+
+  // ─── AUTH-P24: ユーザー一覧閲覧 ──────────────────────────────────────────────
+  // sales: ✕, manager: ✕, admin: ○
+
+  describe('AUTH-P24: ユーザー一覧閲覧', () => {
+    it('sales はユーザー一覧を閲覧できない（403）', async () => {
+      const req = makeRequest(USERS_BASE, 'GET', YAMADA)
+      const res = await listUsers(req, {})
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager はユーザー一覧を閲覧できない（403）', async () => {
+      const req = makeRequest(USERS_BASE, 'GET', TANAKA)
+      const res = await listUsers(req, {})
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin はユーザー一覧を閲覧できる（200）', async () => {
+      const req = makeRequest(USERS_BASE, 'GET', ADMIN)
+      const res = await listUsers(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  // ─── AUTH-P25: ユーザー登録・編集・削除 ───────────────────────────────────────
+  // sales: ✕, manager: ✕, admin: ○
+
+  describe('AUTH-P25: ユーザー登録・編集・削除', () => {
+    const newUserBody = {
+      name: '新規ユーザー',
+      email: 'new-user-perm@test.com',
+      password: 'NewPass1234!',
+      role: 'sales' as const,
+    }
+
+    it('sales はユーザーを登録できない（403）', async () => {
+      const req = makeRequest(USERS_BASE, 'POST', YAMADA, newUserBody)
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager はユーザーを登録できない（403）', async () => {
+      const req = makeRequest(USERS_BASE, 'POST', TANAKA, newUserBody)
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin はユーザーを登録できる（201）', async () => {
+      const req = makeRequest(USERS_BASE, 'POST', ADMIN, newUserBody)
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.email).toBe(newUserBody.email)
+    })
+
+    it('sales はユーザーを編集できない（403）', async () => {
+      const req = makeRequest(`${USERS_BASE}/${SUZUKI.id}`, 'PUT', YAMADA, {
+        name: SUZUKI.name,
+        email: SUZUKI.email,
+        role: 'sales',
+      })
+      const res = await updateUser(req, userIdContext(SUZUKI.id))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager はユーザーを編集できない（403）', async () => {
+      const req = makeRequest(`${USERS_BASE}/${YAMADA.id}`, 'PUT', TANAKA, {
+        name: YAMADA.name,
+        email: YAMADA.email,
+        role: 'sales',
+      })
+      const res = await updateUser(req, userIdContext(YAMADA.id))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin はユーザーを編集できる（200）', async () => {
+      const req = makeRequest(`${USERS_BASE}/${YAMADA.id}`, 'PUT', ADMIN, {
+        name: '山田 太郎（更新）',
+        email: YAMADA.email,
+        role: 'sales',
+      })
+      const res = await updateUser(req, userIdContext(YAMADA.id))
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data.name).toBe('山田 太郎（更新）')
+    })
+
+    it('sales はユーザーを削除できない（403）', async () => {
+      const req = makeRequest(`${USERS_BASE}/${SUZUKI.id}`, 'DELETE', YAMADA)
+      const res = await deleteUser(req, userIdContext(SUZUKI.id))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('manager はユーザーを削除できない（403）', async () => {
+      const req = makeRequest(`${USERS_BASE}/${YAMADA.id}`, 'DELETE', TANAKA)
+      const res = await deleteUser(req, userIdContext(YAMADA.id))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('admin はユーザーを削除できる（204）', async () => {
+      // SUZUKI は日報なしなので削除可能
+      const req = makeRequest(`${USERS_BASE}/${SUZUKI.id}`, 'DELETE', ADMIN)
+      const res = await deleteUser(req, userIdContext(SUZUKI.id))
+
+      expect(res.status).toBe(204)
+    })
+  })
+})

--- a/tests/security/security.test.ts
+++ b/tests/security/security.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET as listReports, POST as createReport } from '@/app/api/reports/route'
+import { GET as getReport } from '@/app/api/reports/[id]/route'
+import { GET as listCustomers, POST as createCustomer } from '@/app/api/customers/route'
+import { GET as getCustomer } from '@/app/api/customers/[id]/route'
+import { POST as createUser } from '@/app/api/users/route'
+import {
+  clearDatabase,
+  seedTestUsers,
+  seedTestCustomers,
+  createTestReport,
+  prisma,
+  TEST_USERS,
+  TEST_CUSTOMERS,
+} from '../helpers/db'
+import { makeToken } from '../helpers/auth'
+import type { AuthUser } from '@/types'
+
+const YAMADA = TEST_USERS.yamada  // sales
+const TANAKA = TEST_USERS.tanaka  // manager
+const ADMIN = TEST_USERS.admin    // admin
+
+const CUST01 = TEST_CUSTOMERS.cust01
+
+const REPORTS_BASE = 'http://localhost/api/reports'
+const CUSTOMERS_BASE = 'http://localhost/api/customers'
+const USERS_BASE = 'http://localhost/api/users'
+
+function makeRequest(
+  url: string,
+  method: string,
+  user: AuthUser,
+  body?: unknown,
+): NextRequest {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${makeToken(user)}`,
+  }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+function makeRequestNoAuth(url: string, method: string, body?: unknown): NextRequest {
+  const headers: Record<string, string> = {}
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+function makeRequestWithToken(url: string, method: string, token: string, body?: unknown): NextRequest {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+function reportIdContext(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+function customerIdContext(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+describe('セキュリティテスト', () => {
+  beforeEach(async () => {
+    await clearDatabase()
+    await seedTestUsers()
+    await seedTestCustomers()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  // ─── SEC-001: トークンなしアクセス → 401 ─────────────────────────────────────
+
+  describe('SEC-001: トークンなしアクセス → 401 UNAUTHORIZED', () => {
+    it('GET /reports にトークンなしでアクセスすると 401 を返す', async () => {
+      const req = makeRequestNoAuth(REPORTS_BASE, 'GET')
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(401)
+      const body = await res.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('GET /customers にトークンなしでアクセスすると 401 を返す', async () => {
+      const req = makeRequestNoAuth(CUSTOMERS_BASE, 'GET')
+      const res = await listCustomers(req, {})
+
+      expect(res.status).toBe(401)
+      const body = await res.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('POST /users にトークンなしでアクセスすると 401 を返す', async () => {
+      const req = makeRequestNoAuth(USERS_BASE, 'POST', {
+        name: 'テスト',
+        email: 'test@test.com',
+        password: 'Test1234!',
+        role: 'sales',
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(401)
+      const body = await res.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  // ─── SEC-002: 不正トークン → 401 ──────────────────────────────────────────────
+
+  describe('SEC-002: 不正トークン → 401 UNAUTHORIZED', () => {
+    it('改ざんされたトークンで GET /reports にアクセスすると 401 を返す', async () => {
+      const req = makeRequestWithToken(REPORTS_BASE, 'GET', 'invalid.token.here')
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(401)
+      const body = await res.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('有効期限切れトークン形式で GET /customers にアクセスすると 401 を返す', async () => {
+      // JWT の構造を持つが署名が不正なトークン
+      const fakeToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+        '.eyJpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImlhdCI6MTYwMDAwMDAwMCwiZXhwIjoxNjAwMDAwMDAxfQ' +
+        '.invalid_signature_here'
+
+      const req = makeRequestWithToken(CUSTOMERS_BASE, 'GET', fakeToken)
+      const res = await listCustomers(req, {})
+
+      expect(res.status).toBe(401)
+      const body = await res.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('空文字列トークンで GET /reports にアクセスすると 401 を返す', async () => {
+      const req = makeRequestWithToken(REPORTS_BASE, 'GET', '')
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(401)
+      const body = await res.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    })
+  })
+
+  // ─── SEC-003: 他人の日報アクセス（sales） → 403 ──────────────────────────────
+
+  describe('SEC-003: 他人の日報アクセス（sales） → 403 FORBIDDEN', () => {
+    it('sales（YAMADA）が sales（SUZUKI）の日報詳細にアクセスすると 403 を返す', async () => {
+      const suzuki = TEST_USERS.suzuki
+      const reportId = await createTestReport({
+        userId: suzuki.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '鈴木の訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', YAMADA)
+      const res = await getReport(req, reportIdContext(reportId))
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.code).toBe('FORBIDDEN')
+    })
+
+    it('sales（YAMADA）の日報一覧にはYAMADA自身の日報のみ含まれる', async () => {
+      const suzuki = TEST_USERS.suzuki
+
+      await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '山田訪問', sortOrder: 1 }],
+      })
+      await createTestReport({
+        userId: suzuki.id,
+        reportDate: '2026-04-25',
+        visitRecords: [{ customerId: CUST01.id, content: '鈴木訪問', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(REPORTS_BASE, 'GET', YAMADA)
+      const res = await listReports(req, {})
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // sales は自分の分しか返らない
+      body.data.forEach((report: { user: { id: string } }) => {
+        expect(report.user.id).toBe(YAMADA.id)
+      })
+    })
+  })
+
+  // ─── SEC-004: SQL インジェクション → エラーなし ───────────────────────────────
+
+  describe('SEC-004: SQL インジェクション → 500 にならない（正常または 400）', () => {
+    it('顧客名に SQL インジェクションパターンを含めても 500 にならない', async () => {
+      const req = makeRequest(CUSTOMERS_BASE, 'POST', YAMADA, {
+        name: "'; DROP TABLE users; --",
+        company: '株式会社テスト',
+      })
+      const res = await createCustomer(req, {})
+
+      // 500 (Internal Server Error) にならないこと
+      expect(res.status).not.toBe(500)
+      // 作成成功（201）または バリデーションエラー（400）のいずれか
+      expect([200, 201, 400, 422]).toContain(res.status)
+    })
+
+    it('顧客検索クエリに SQL インジェクションパターンを含めても 500 にならない', async () => {
+      const injectionQuery = encodeURIComponent("'; DROP TABLE customers; --")
+      const req = makeRequest(`${CUSTOMERS_BASE}?q=${injectionQuery}`, 'GET', YAMADA)
+      const res = await listCustomers(req, {})
+
+      // 500 (Internal Server Error) にならないこと
+      expect(res.status).not.toBe(500)
+      expect(res.status).toBe(200)
+    })
+
+    it('日報作成の problem フィールドに SQL インジェクションパターンを含めても 500 にならない', async () => {
+      const req = makeRequest(REPORTS_BASE, 'POST', YAMADA, {
+        report_date: '2026-05-01',
+        problem: "'; DELETE FROM daily_reports WHERE '1'='1",
+        plan: 'テスト計画',
+        visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      // 500 (Internal Server Error) にならないこと
+      expect(res.status).not.toBe(500)
+      expect([200, 201, 400]).toContain(res.status)
+    })
+  })
+
+  // ─── SEC-005: XSS → エスケープ表示（API は保存・取得が正常に動作） ────────────
+
+  describe('SEC-005: XSS → API は入力をそのまま保存・取得（フロントでエスケープ）', () => {
+    it('顧客名に XSS スクリプトを含めて作成・取得しても同じ文字列が返る', async () => {
+      const xssPayload = '<script>alert(1)</script>'
+
+      const createReq = makeRequest(CUSTOMERS_BASE, 'POST', YAMADA, {
+        name: xssPayload,
+        company: '株式会社XSSテスト',
+      })
+      const createRes = await createCustomer(createReq, {})
+
+      expect(createRes.status).toBe(201)
+      const createBody = await createRes.json()
+      const customerId: string = createBody.data.id
+
+      // 取得して同じ文字列が返ること（API レイヤーでの変換なし）
+      const getReq = makeRequest(`${CUSTOMERS_BASE}/${customerId}`, 'GET', YAMADA)
+      const getRes = await getCustomer(getReq, customerIdContext(customerId))
+
+      expect(getRes.status).toBe(200)
+      const getBody = await getRes.json()
+      expect(getBody.data.name).toBe(xssPayload)
+    })
+
+    it('日報の problem フィールドに XSS スクリプトを含めて作成・取得しても同じ文字列が返る', async () => {
+      const xssPayload = '<img src=x onerror=alert(1)>'
+
+      const createReq = makeRequest(REPORTS_BASE, 'POST', YAMADA, {
+        report_date: '2026-05-02',
+        problem: xssPayload,
+        plan: 'テスト計画',
+        visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+      })
+      const createRes = await createReport(createReq, {})
+
+      expect(createRes.status).toBe(201)
+      const createBody = await createRes.json()
+      const reportId: string = createBody.data.id
+
+      // 取得して同じ文字列が返ること（API レイヤーでの変換なし）
+      const getReq = makeRequest(`${REPORTS_BASE}/${reportId}`, 'GET', YAMADA)
+      const getRes = await getReport(getReq, reportIdContext(reportId))
+
+      expect(getRes.status).toBe(200)
+      const getBody = await getRes.json()
+      expect(getBody.data.problem).toBe(xssPayload)
+    })
+  })
+
+  // ─── SEC-006: パスワードハッシュ保存確認 ─────────────────────────────────────
+
+  describe('SEC-006: パスワードはハッシュ化されて保存される', () => {
+    it('ユーザー作成後、DB の passwordHash が bcrypt ハッシュ形式で保存される', async () => {
+      const plainPassword = 'SecurePass1234!'
+
+      const req = makeRequest(USERS_BASE, 'POST', ADMIN, {
+        name: 'ハッシュテスト',
+        email: 'hashtest@test.com',
+        password: plainPassword,
+        role: 'sales',
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      const userId: string = body.data.id
+
+      // DB から直接 passwordHash を取得
+      const userInDb = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { passwordHash: true },
+      })
+
+      expect(userInDb).not.toBeNull()
+      expect(userInDb!.passwordHash).not.toBe(plainPassword)
+      // bcrypt ハッシュ形式（$2a$ または $2b$ で始まる）であることを確認
+      expect(userInDb!.passwordHash).toMatch(/^\$2[ab]\$/)
+    })
+
+    it('ユーザー作成 API のレスポンスにパスワードハッシュが含まれない', async () => {
+      const req = makeRequest(USERS_BASE, 'POST', ADMIN, {
+        name: 'パスワード非公開テスト',
+        email: 'nopwdhash@test.com',
+        password: 'SecurePass1234!',
+        role: 'sales',
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+
+      // レスポンスにパスワード関連フィールドが含まれないこと
+      expect(body.data).not.toHaveProperty('passwordHash')
+      expect(body.data).not.toHaveProperty('password')
+      expect(body.data).not.toHaveProperty('password_hash')
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
 
     // テスト対象ファイルパターン
     include: ['**/*.{test,spec}.{ts,tsx}'],
-    exclude: ['node_modules/**', '.next/**', 'dist/**', 'issue-*/**'],
+    exclude: ['node_modules/**', '.next/**', 'dist/**', 'issue-*/**', 'tests/api/**', 'tests/auth/**', 'tests/security/**'],
 
     coverage: {
       provider: 'v8',

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -5,11 +5,11 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['tests/api/**/*.test.ts'],
+    include: ['tests/api/**/*.test.ts', 'tests/auth/**/*.test.ts', 'tests/security/**/*.test.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
     env: {
-      DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/sales_report_test',
+      DATABASE_URL: 'postgresql://postgres:postgres@db:5432/sales_report_test',
       JWT_SECRET: 'test-jwt-secret',
       NODE_ENV: 'test',
     },

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -8,8 +8,12 @@ export default defineConfig({
     include: ['tests/api/**/*.test.ts', 'tests/auth/**/*.test.ts', 'tests/security/**/*.test.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
+    // DATABASE_URL は .env.test から読み込む。
+    // Docker コンテナ内 (docker compose exec app) で実行する際は db:5432 を使用。
+    // ホスト環境から直接実行する場合は環境変数で上書きしてください:
+    //   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/sales_report_test npx vitest ...
     env: {
-      DATABASE_URL: 'postgresql://postgres:postgres@db:5432/sales_report_test',
+      DATABASE_URL: process.env['DATABASE_URL'] ?? 'postgresql://postgres:postgres@db:5432/sales_report_test',
       JWT_SECRET: 'test-jwt-secret',
       NODE_ENV: 'test',
     },


### PR DESCRIPTION
## Summary
- AUTH-P01〜P06: 日報操作の全ロール権限テストを実装
- AUTH-P11〜P14: コメント操作の全ロール権限テストを実装
- AUTH-P21〜P25: 顧客・ユーザー操作の全ロール権限テストを実装
- SEC-001〜006: セキュリティテスト（401/403/SQLi/XSS/パスワードハッシュ）を実装

## Test plan
- [ ] `tests/auth/permissions.test.ts` 全テスト通過
- [ ] `tests/security/security.test.ts` 全テスト通過
- [ ] TypeScript 型エラーなし
- [ ] ESLint エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)