### PR TITLE
test: Issue 29 バリデーションテスト（VAL-001〜043）を実装

### DIFF
--- a/tests/validation/comment.test.ts
+++ b/tests/validation/comment.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST as createComment } from '@/app/api/reports/[id]/comments/route'
+import {
+  clearDatabase,
+  seedTestUsers,
+  seedTestCustomers,
+  createTestReport,
+  prisma,
+  TEST_USERS,
+  TEST_CUSTOMERS,
+} from '../helpers/db'
+import { makeToken } from '../helpers/auth'
+
+const TANAKA = TEST_USERS.tanaka // manager
+const YAMADA = TEST_USERS.yamada // sales（日報作成用）
+const CUST01 = TEST_CUSTOMERS.cust01
+
+const BASE = 'http://localhost/api/reports'
+
+function makeRequest(reportId: string, body?: unknown): NextRequest {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${makeToken(TANAKA)}`,
+  }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(`${BASE}/${reportId}/comments`, {
+    method: 'POST',
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+function reportContext(reportId: string) {
+  return { params: Promise.resolve({ id: reportId }) }
+}
+
+describe('コメントバリデーション', () => {
+  beforeEach(async () => {
+    await clearDatabase()
+    await seedTestUsers()
+    await seedTestCustomers()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  // VAL-041: コメント本文空欄 → 400, VALIDATION_ERROR
+  describe('VAL-041: コメント本文空欄 → 400, VALIDATION_ERROR', () => {
+    it('コメント本文が空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(reportId, { body: '' })
+      const res = await createComment(req, reportContext(reportId))
+
+      expect(res.status).toBe(400)
+      const resBody = await res.json()
+      expect(resBody.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-042: コメント本文2001文字 → 400, VALIDATION_ERROR
+  describe('VAL-042: コメント本文2001文字 → 400, VALIDATION_ERROR', () => {
+    it('コメント本文が2001文字の場合400とVALIDATION_ERRORを返す', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const req = makeRequest(reportId, { body: 'あ'.repeat(2001) })
+      const res = await createComment(req, reportContext(reportId))
+
+      expect(res.status).toBe(400)
+      const resBody = await res.json()
+      expect(resBody.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-043: コメント本文2000文字 → 201（正常・境界値）
+  describe('VAL-043: コメント本文2000文字 → 201（正常）', () => {
+    it('コメント本文が2000文字の場合201と作成コメントを返す（境界値）', async () => {
+      const reportId = await createTestReport({
+        userId: YAMADA.id,
+        reportDate: '2026-05-01',
+        visitRecords: [{ customerId: CUST01.id, content: '訪問内容', sortOrder: 1 }],
+      })
+
+      const body2000 = 'あ'.repeat(2000)
+      const req = makeRequest(reportId, { body: body2000 })
+      const res = await createComment(req, reportContext(reportId))
+
+      expect(res.status).toBe(201)
+      const resBody = await res.json()
+      expect(resBody.data).toHaveProperty('id')
+      expect(resBody.data.body).toBe(body2000)
+      expect(resBody.data.commenter.id).toBe(TANAKA.id)
+    })
+  })
+})

--- a/tests/validation/customer.test.ts
+++ b/tests/validation/customer.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST as createCustomer } from '@/app/api/customers/route'
+import {
+  clearDatabase,
+  seedTestUsers,
+  seedTestCustomers,
+  prisma,
+  TEST_USERS,
+} from '../helpers/db'
+import { makeToken } from '../helpers/auth'
+
+const YAMADA = TEST_USERS.yamada // sales
+
+const BASE = 'http://localhost/api/customers'
+
+function makeRequest(body?: unknown): NextRequest {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${makeToken(YAMADA)}`,
+  }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(BASE, {
+    method: 'POST',
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('顧客マスタバリデーション', () => {
+  beforeEach(async () => {
+    await clearDatabase()
+    await seedTestUsers()
+    await seedTestCustomers()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  // VAL-021: 顧客名空欄 → 400, VALIDATION_ERROR
+  describe('VAL-021: 顧客名空欄 → 400, VALIDATION_ERROR', () => {
+    it('顧客名が空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({ name: '' })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-022: 顧客名101文字 → 400, VALIDATION_ERROR
+  describe('VAL-022: 顧客名101文字 → 400, VALIDATION_ERROR', () => {
+    it('顧客名が101文字の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({ name: 'あ'.repeat(101) })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-023: 顧客名1文字 → 201（正常）
+  describe('VAL-023: 顧客名1文字 → 201（正常）', () => {
+    it('顧客名が1文字の場合201と作成データを返す', async () => {
+      const req = makeRequest({ name: 'あ' })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.name).toBe('あ')
+    })
+  })
+
+  // VAL-024: 顧客名100文字 → 201（正常）
+  describe('VAL-024: 顧客名100文字 → 201（正常）', () => {
+    it('顧客名が100文字の場合201と作成データを返す', async () => {
+      const name = 'あ'.repeat(100)
+      const req = makeRequest({ name })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.name).toBe(name)
+    })
+  })
+
+  // VAL-025: メールアドレスが不正形式 → 400, VALIDATION_ERROR
+  describe('VAL-025: メールアドレスが不正形式 → 400, VALIDATION_ERROR', () => {
+    it('メールアドレスが不正形式の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({ name: '正常な顧客名', email: 'not-an-email' })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-026: メールアドレス空欄 → 201（任意項目なので正常）
+  describe('VAL-026: メールアドレス空欄 → 201（任意項目）', () => {
+    it('メールアドレスが指定されない場合も201と作成データを返す（任意項目）', async () => {
+      const req = makeRequest({ name: 'メールなし顧客' })
+      const res = await createCustomer(req, {})
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.name).toBe('メールなし顧客')
+    })
+  })
+})

--- a/tests/validation/customer.test.ts
+++ b/tests/validation/customer.test.ts
@@ -4,7 +4,6 @@ import { POST as createCustomer } from '@/app/api/customers/route'
 import {
   clearDatabase,
   seedTestUsers,
-  seedTestCustomers,
   prisma,
   TEST_USERS,
 } from '../helpers/db'
@@ -30,7 +29,6 @@ describe('顧客マスタバリデーション', () => {
   beforeEach(async () => {
     await clearDatabase()
     await seedTestUsers()
-    await seedTestCustomers()
   })
 
   afterAll(async () => {

--- a/tests/validation/login.test.ts
+++ b/tests/validation/login.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST as loginPost } from '@/app/api/auth/login/route'
+import { clearDatabase, seedTestUsers, prisma } from '../helpers/db'
+
+const BASE = 'http://localhost/api/auth/login'
+
+function makeRequest(body?: unknown): NextRequest {
+  const headers: Record<string, string> = {}
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(BASE, {
+    method: 'POST',
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('ログインAPIバリデーション', () => {
+  beforeEach(async () => {
+    await clearDatabase()
+    await seedTestUsers()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  // VAL-001: メールアドレス空欄 → 400, VALIDATION_ERROR
+  describe('VAL-001: メールアドレス空欄 → 400, VALIDATION_ERROR', () => {
+    it('メールアドレスが空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({ email: '', password: 'Test1234!' })
+      const res = await loginPost(req)
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-002: メールアドレスが plain text（メール形式でない） → 400, VALIDATION_ERROR
+  describe('VAL-002: メールアドレスが不正形式 → 400, VALIDATION_ERROR', () => {
+    it('メールアドレスがメール形式でない場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({ email: 'not-an-email', password: 'Test1234!' })
+      const res = await loginPost(req)
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-003: パスワード空欄 → 400, VALIDATION_ERROR
+  describe('VAL-003: パスワード空欄 → 400, VALIDATION_ERROR', () => {
+    it('パスワードが空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({ email: 'yamada@test.com', password: '' })
+      const res = await loginPost(req)
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+})

--- a/tests/validation/report.test.ts
+++ b/tests/validation/report.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST as createReport } from '@/app/api/reports/route'
+import {
+  clearDatabase,
+  seedTestUsers,
+  seedTestCustomers,
+  prisma,
+  TEST_USERS,
+  TEST_CUSTOMERS,
+} from '../helpers/db'
+import { makeToken } from '../helpers/auth'
+
+const YAMADA = TEST_USERS.yamada // sales
+const CUST01 = TEST_CUSTOMERS.cust01
+
+const BASE = 'http://localhost/api/reports'
+
+function makeRequest(body?: unknown): NextRequest {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${makeToken(YAMADA)}`,
+  }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(BASE, {
+    method: 'POST',
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('日報作成バリデーション', () => {
+  beforeEach(async () => {
+    await clearDatabase()
+    await seedTestUsers()
+    await seedTestCustomers()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  // VAL-011: 対象日空欄 → 400, VALIDATION_ERROR
+  describe('VAL-011: 対象日空欄 → 400, VALIDATION_ERROR', () => {
+    it('対象日が空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '',
+        problem: 'テスト課題',
+        plan: 'テスト計画',
+        visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-012: 対象日が未来日（2099-12-31） → 400, VALIDATION_ERROR（今日以前の日付）
+  describe('VAL-012: 対象日が未来日 → 400, VALIDATION_ERROR', () => {
+    it('対象日が未来日の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '2099-12-31',
+        problem: 'テスト課題',
+        plan: 'テスト計画',
+        visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-013: 顧客未選択（visit_records が空配列） → 400, VALIDATION_ERROR
+  describe('VAL-013: 顧客未選択 → 400, VALIDATION_ERROR', () => {
+    it('visit_recordsが空配列の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '2026-05-01',
+        problem: 'テスト課題',
+        plan: 'テスト計画',
+        visit_records: [],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-014: 訪問内容空欄 → 400, VALIDATION_ERROR
+  describe('VAL-014: 訪問内容空欄 → 400, VALIDATION_ERROR', () => {
+    it('訪問内容が空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '2026-05-01',
+        problem: 'テスト課題',
+        plan: 'テスト計画',
+        visit_records: [{ customer_id: CUST01.id, content: '', sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-015: 訪問内容1001文字 → 400, VALIDATION_ERROR（1000文字以内）
+  describe('VAL-015: 訪問内容1001文字 → 400, VALIDATION_ERROR', () => {
+    it('訪問内容が1001文字の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '2026-05-01',
+        problem: 'テスト課題',
+        plan: 'テスト計画',
+        visit_records: [{ customer_id: CUST01.id, content: 'あ'.repeat(1001), sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-016: Problem空欄 → 400, VALIDATION_ERROR
+  describe('VAL-016: Problem空欄 → 400, VALIDATION_ERROR', () => {
+    it('problemが空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '2026-05-01',
+        problem: '',
+        plan: 'テスト計画',
+        visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-017: Problem 2001文字 → 400, VALIDATION_ERROR（2000文字以内）
+  describe('VAL-017: Problem 2001文字 → 400, VALIDATION_ERROR', () => {
+    it('problemが2001文字の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '2026-05-01',
+        problem: 'あ'.repeat(2001),
+        plan: 'テスト計画',
+        visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-018: Plan空欄 → 400, VALIDATION_ERROR
+  describe('VAL-018: Plan空欄 → 400, VALIDATION_ERROR', () => {
+    it('planが空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '2026-05-01',
+        problem: 'テスト課題',
+        plan: '',
+        visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-019: Plan 2001文字 → 400, VALIDATION_ERROR（2000文字以内）
+  describe('VAL-019: Plan 2001文字 → 400, VALIDATION_ERROR', () => {
+    it('planが2001文字の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        report_date: '2026-05-01',
+        problem: 'テスト課題',
+        plan: 'あ'.repeat(2001),
+        visit_records: [{ customer_id: CUST01.id, content: '訪問内容', sort_order: 1 }],
+      })
+      const res = await createReport(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+})

--- a/tests/validation/user.test.ts
+++ b/tests/validation/user.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST as createUser } from '@/app/api/users/route'
+import {
+  clearDatabase,
+  seedTestUsers,
+  seedTestCustomers,
+  prisma,
+  TEST_USERS,
+} from '../helpers/db'
+import { makeToken } from '../helpers/auth'
+
+const ADMIN = TEST_USERS.admin // admin
+
+const BASE = 'http://localhost/api/users'
+
+function makeRequest(body?: unknown): NextRequest {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${makeToken(ADMIN)}`,
+  }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  return new NextRequest(BASE, {
+    method: 'POST',
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('ユーザー登録バリデーション', () => {
+  beforeEach(async () => {
+    await clearDatabase()
+    await seedTestUsers()
+    await seedTestCustomers()
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  // VAL-031: 氏名空欄 → 400, VALIDATION_ERROR
+  describe('VAL-031: 氏名空欄 → 400, VALIDATION_ERROR', () => {
+    it('氏名が空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        name: '',
+        email: 'newuser@test.com',
+        password: 'Test1234!',
+        role: 'sales',
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-032: メールアドレス空欄 → 400, VALIDATION_ERROR
+  describe('VAL-032: メールアドレス空欄 → 400, VALIDATION_ERROR', () => {
+    it('メールアドレスが空欄の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        name: '新規ユーザー',
+        email: '',
+        password: 'Test1234!',
+        role: 'sales',
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-033: 既存メールアドレス → 409, EMAIL_ALREADY_EXISTS
+  describe('VAL-033: 既存メールアドレス → 409, EMAIL_ALREADY_EXISTS', () => {
+    it('既存ユーザーと同じメールアドレスで登録すると409とEMAIL_ALREADY_EXISTSを返す', async () => {
+      const req = makeRequest({
+        name: '重複ユーザー',
+        email: TEST_USERS.yamada.email, // 既存のメールアドレス
+        password: 'Test1234!',
+        role: 'sales',
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.error.code).toBe('EMAIL_ALREADY_EXISTS')
+    })
+  })
+
+  // VAL-034: パスワード7文字 → 400, VALIDATION_ERROR（8文字以上）
+  describe('VAL-034: パスワード7文字 → 400, VALIDATION_ERROR', () => {
+    it('パスワードが7文字の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        name: '新規ユーザー',
+        email: 'newuser@test.com',
+        password: '1234567', // 7文字
+        role: 'sales',
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+
+  // VAL-035: パスワード8文字 → 201（正常）
+  describe('VAL-035: パスワード8文字 → 201（正常）', () => {
+    it('パスワードが8文字の場合201と作成ユーザーを返す', async () => {
+      const req = makeRequest({
+        name: '新規ユーザー',
+        email: 'newuser@test.com',
+        password: '12345678', // 8文字（境界値）
+        role: 'sales',
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data.name).toBe('新規ユーザー')
+      expect(body.data.email).toBe('newuser@test.com')
+      expect(body.data.role).toBe('sales')
+      // パスワードハッシュが返らないことを確認
+      expect(body.data).not.toHaveProperty('passwordHash')
+      expect(body.data).not.toHaveProperty('password')
+    })
+  })
+
+  // VAL-036: ロール未指定 → 400, VALIDATION_ERROR
+  describe('VAL-036: ロール未指定 → 400, VALIDATION_ERROR', () => {
+    it('ロールが未指定の場合400とVALIDATION_ERRORを返す', async () => {
+      const req = makeRequest({
+        name: '新規ユーザー',
+        email: 'newuser@test.com',
+        password: 'Test1234!',
+        // role を省略
+      })
+      const res = await createUser(req, {})
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+  })
+})

--- a/tests/validation/user.test.ts
+++ b/tests/validation/user.test.ts
@@ -4,7 +4,6 @@ import { POST as createUser } from '@/app/api/users/route'
 import {
   clearDatabase,
   seedTestUsers,
-  seedTestCustomers,
   prisma,
   TEST_USERS,
 } from '../helpers/db'
@@ -30,7 +29,6 @@ describe('ユーザー登録バリデーション', () => {
   beforeEach(async () => {
     await clearDatabase()
     await seedTestUsers()
-    await seedTestCustomers()
   })
 
   afterAll(async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
 
     // テスト対象ファイルパターン
     include: ['**/*.{test,spec}.{ts,tsx}'],
-    exclude: ['node_modules/**', '.next/**', 'dist/**', 'issue-*/**', 'tests/api/**', 'tests/auth/**', 'tests/security/**'],
+    exclude: ['node_modules/**', '.next/**', 'dist/**', 'issue-*/**', 'tests/api/**', 'tests/auth/**', 'tests/security/**', 'tests/validation/**'],
 
     coverage: {
       provider: 'v8',

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['tests/api/**/*.test.ts', 'tests/auth/**/*.test.ts', 'tests/security/**/*.test.ts'],
+    include: ['tests/api/**/*.test.ts', 'tests/auth/**/*.test.ts', 'tests/security/**/*.test.ts', 'tests/validation/**/*.test.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
     // DATABASE_URL は .env.test から読み込む。


### PR DESCRIPTION
## Summary
- VAL-001〜003: ログインAPIバリデーションテストを実装
- VAL-011〜019: 日報作成バリデーションテストを実装
- VAL-021〜026: 顧客マスタバリデーションテストを実装
- VAL-031〜036: ユーザー登録バリデーションテストを実装
- VAL-041〜043: コメントバリデーションテストを実装

Closes #29

## Test plan
- [ ] tests/validation/ 全テスト通過
- [ ] TypeScript 型エラーなし
- [ ] ESLint エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)