### PR TITLE
fix: CommentSection の Comment型フィールド名を commenter に修正

### DIFF
--- a/src/components/reports/CommentSection.test.tsx
+++ b/src/components/reports/CommentSection.test.tsx
@@ -51,13 +51,13 @@ const mockComments: Comment[] = [
   {
     id: 'comment-1',
     body: 'コメント本文1',
-    user: { id: 'user-manager-1', name: '田中 部長' },
+    commenter: { id: 'user-manager-1', name: '田中 部長', role: 'manager' },
     created_at: '2026-05-01T10:00:00Z',
   },
   {
     id: 'comment-2',
     body: 'コメント本文2',
-    user: { id: 'user-manager-2', name: '佐藤 部長' },
+    commenter: { id: 'user-manager-2', name: '佐藤 部長', role: 'manager' },
     created_at: '2026-05-01T09:00:00Z',
   },
 ]
@@ -144,7 +144,7 @@ describe('CommentSection', () => {
       const newComment: Comment = {
         id: 'comment-new',
         body: '新しいコメント',
-        user: { id: 'user-manager-1', name: '田中 部長' },
+        commenter: { id: 'user-manager-1', name: '田中 部長', role: 'manager' },
         created_at: '2026-05-02T10:00:00Z',
       }
       vi.mocked(apiClient.post).mockResolvedValue({ data: newComment })
@@ -169,7 +169,7 @@ describe('CommentSection', () => {
       const newComment: Comment = {
         id: 'comment-new',
         body: '新しいコメント',
-        user: { id: 'user-manager-1', name: '田中 部長' },
+        commenter: { id: 'user-manager-1', name: '田中 部長', role: 'manager' },
         created_at: '2026-05-02T10:00:00Z',
       }
       vi.mocked(apiClient.post).mockResolvedValue({ data: newComment })

--- a/src/components/reports/CommentSection.tsx
+++ b/src/components/reports/CommentSection.tsx
@@ -22,7 +22,7 @@ import type { AuthUser } from '@/types'
 export interface Comment {
   id: string
   body: string
-  user: { id: string; name: string }
+  commenter: { id: string; name: string; role: string }
   created_at: string
 }
 
@@ -97,7 +97,7 @@ export function CommentSection({
 
   function canDeleteComment(comment: Comment): boolean {
     if (currentUser.role === 'admin') return true
-    return comment.user.id === currentUser.id
+    return comment.commenter.id === currentUser.id
   }
 
   return (
@@ -125,7 +125,7 @@ export function CommentSection({
             >
               <div className="flex items-center justify-between gap-2">
                 <span className="text-sm font-medium">
-                  {comment.user.name}
+                  {comment.commenter.name}
                   <span className="ml-2 text-xs text-muted-foreground font-normal">
                     {formatDateTimeJst(comment.created_at)}
                   </span>
@@ -137,7 +137,7 @@ export function CommentSection({
                     size="sm"
                     className="text-destructive hover:text-destructive hover:bg-destructive/10"
                     onClick={() => void handleDelete(comment.id)}
-                    aria-label={`${comment.user.name}のコメントを削除`}
+                    aria-label={`${comment.commenter.name}のコメントを削除`}
                   >
                     <Trash2 className="h-4 w-4" aria-hidden="true" />
                     削除


### PR DESCRIPTION
## Summary

Closes #61

- `CommentSection.tsx` の `Comment` インターフェースで `user` と定義していたフィールドを、APIレスポンスの実際のフィールド名 `commenter` に修正
- テンプレート内の参照（表示・aria-label・削除権限チェック）を合わせて修正
- テストデータも同様に修正

## Test plan

- [ ] `npx vitest run src/components/reports/CommentSection.test.tsx` が全件パス
- [ ] adminまたはmanagerユーザーでコメントを投稿し、エラーなく表示されることを確認
- [ ] コメント削除ボタンが正しく表示・動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)